### PR TITLE
Do not require all Druxt modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ Add module to `nuxt.config.js`
 module.exports = {
   modules: [
     ...
-    'druxt'
+    'druxt',
+    // Additional Druxt modules.
+    'druxt-blocks',
+    'druxt-breadcrumb',
+    'druxt-entity',
+    'druxt-menu',
+    'druxt-schema',
+    'druxt-search',
+    'druxt-views'
   ],
 
   druxt: {

--- a/src/module.js
+++ b/src/module.js
@@ -22,14 +22,7 @@ const DruxtModule = function (moduleOptions = {}) {
   // Add NuxtJS modules.
   const modules = [
     '@nuxtjs/proxy',
-    'druxt-blocks',
-    'druxt-breadcrumb',
-    'druxt-entity',
-    'druxt-menu',
     'druxt-router',
-    'druxt-schema',
-    'druxt-search',
-    'druxt-views'
   ]
   for (const key in modules) {
     this.addModule(modules[key])


### PR DESCRIPTION
Maybe this isn't the right approach. Maybe there needs to be feature flags that turn off specific modules. But this is a first approach.

Fixes #13﻿
