### PR TITLE
[#63] Add support for custom Axios instance / @nuxtjs/axios

### DIFF
--- a/.changeset/heavy-comics-sell.md
+++ b/.changeset/heavy-comics-sell.md
@@ -1,0 +1,5 @@
+---
+"druxt": minor
+---
+
+Added support for @nuxtjs/axios module

--- a/packages/druxt/nuxt/plugin.js
+++ b/packages/druxt/nuxt/plugin.js
@@ -10,7 +10,11 @@ export default (context, inject) => {
 
   <% if (typeof options.axios === 'object') { %>
   // Axios settings.
+  console.warn('[druxt] Axios instance settings are deprecated, use @nuxtjs/axios module configuration instead.')
   options.axios = <%= JSON.stringify(options.axios) %>
+  <% } else { %>
+  // Use the @nuxtjs/axios module Axios instance.
+  options.axios = context.app.$axios
   <% } %>
 
   const druxt = new DruxtClient(baseUrl, options)

--- a/packages/druxt/package.json
+++ b/packages/druxt/package.json
@@ -42,7 +42,7 @@
     "nuxt"
   ],
   "dependencies": {
-    "axios": "^0.21.1",
+    "@nuxtjs/axios": "^5.13.6",
     "deepmerge": "^4.2.2",
     "drupal-jsonapi-params": "^1.2.1",
     "md5": "^2.3.0",

--- a/packages/druxt/package.json
+++ b/packages/druxt/package.json
@@ -42,12 +42,15 @@
     "nuxt"
   ],
   "dependencies": {
-    "@nuxtjs/axios": "^5.13.6",
+    "axios": "^0.21.4",
     "deepmerge": "^4.2.2",
     "drupal-jsonapi-params": "^1.2.1",
     "md5": "^2.3.0",
     "querystring": "^0.2.0",
     "scule": "^0.2.0"
+  },
+  "peerDependencies": {
+    "@nuxtjs/axios": "^5.13.6"
   },
   "optionalDependencies": {
     "core-js": "^3.16.1",

--- a/packages/druxt/src/client.js
+++ b/packages/druxt/src/client.js
@@ -25,20 +25,25 @@ class DruxtClient {
       throw new Error('The \'baseUrl\' parameter is required.')
     }
 
-    // Setup Axios.
-    let axiosSettings = { baseURL: baseUrl }
-    if (typeof options.axios === 'object') {
-      axiosSettings = Object.assign(axiosSettings, options.axios)
-      delete options.axios
-    }
-
     /**
      * The Axios instance.
      *
      * @see {@link https://github.com/axios/axios#instance-methods}
      * @type {object}
      */
-    this.axios = axios.create(axiosSettings)
+    this.axios = {}
+    // Use Axios instance if provided.
+    if (typeof options.axios === 'function') {
+      this.axios = options.axios
+    }
+
+    // Else, setup new instance of Axios.
+    else {
+      this.axios = axios.create({
+        ...options.axios || {},
+        baseURL: baseUrl,
+      })
+    }
 
     /**
      * Druxt base options.

--- a/packages/druxt/src/nuxtModule.js
+++ b/packages/druxt/src/nuxtModule.js
@@ -33,6 +33,28 @@ const DruxtNuxtModule = function (moduleOptions = {}) {
     dirs.push({ path: join(__dirname, 'components') })
   })
 
+  // Install the @nuxtjs/axios module.
+  this.options.axios = {
+    baseURL: options.baseUrl,
+    ...this.options.axios
+  }
+  this.addModule('@nuxtjs/axios')
+
+  // Ensure Axios plugin is loaded before Druxt plugin.
+  const extendPluginsFn = this.options.extendPlugins
+  this.options.extendPlugins = (plugins) => {
+    if (typeof extendPluginsFn === 'function') {
+      plugins = extendPluginsFn(plugins)
+    }
+    const axiosIndex = plugins.findIndex(
+      ({ src }) => src === this.options.buildDir + '/axios.js'
+    )
+    const axiosPlugin = plugins[axiosIndex]
+
+    plugins.splice(axiosIndex, 1)
+    plugins.unshift(axiosPlugin)
+  }
+
   // Add plugin.
   this.addPlugin({
     src: resolve(__dirname, '../nuxt/plugin.js'),

--- a/packages/druxt/test/client.test.js
+++ b/packages/druxt/test/client.test.js
@@ -28,6 +28,12 @@ describe('DruxtClient', () => {
     const headers = { 'X-Druxt': true }
     expect(new DruxtClient(baseUrl, { axios: { headers } })).toBeInstanceOf(DruxtClient)
     expect(mockAxios.create).toHaveBeenCalledWith({ baseURL: baseUrl, headers })
+
+    // Instantiate client with custom axios instance.
+    const axios = jest.fn()
+    const client = new DruxtClient(baseUrl, { axios })
+    expect(client).toBeInstanceOf(DruxtClient)
+    expect(client.axios).toStrictEqual(axios)
   })
 
   test('addHeaders', () => {

--- a/packages/druxt/test/nuxtModule.test.js
+++ b/packages/druxt/test/nuxtModule.test.js
@@ -9,6 +9,7 @@ let mock
 describe('DruxtJS Nuxt module', () => {
   beforeEach(() => {
     mock = {
+      addModule: jest.fn(),
       addPlugin: jest.fn(),
       nuxt: {
         hook: jest.fn((hook, fn) => {
@@ -19,7 +20,9 @@ describe('DruxtJS Nuxt module', () => {
           return fn(arg[hook])
         }),
       },
-      options: {},
+      options: {
+        buildDir: 'build',
+      },
       DruxtNuxtModule
     }
   })
@@ -41,5 +44,20 @@ describe('DruxtJS Nuxt module', () => {
 
     // Expect addPlugin to have been called with options.
     expect(mock.addPlugin).toHaveBeenCalledWith(expect.objectContaining({ options }))
+  })
+
+  test('@nuxtjs/axios module', () => {
+    mock.options.extendPlugins = jest.fn((o) => o)
+
+    DruxtNuxtModule.call(mock)
+
+    // Expect addModule to have been called to install @nuxtjs/axios.
+    expect(mock.addModule).toHaveBeenCalledWith('@nuxtjs/axios')
+
+    // Expect the Axios plugin to be the first in the list.
+    const mockPlugins = [{ src: 'test' }, { src: 'build/axios.js' }]
+    expect(typeof mock.options.extendPlugins).toBe('function')
+    mock.options.extendPlugins(mockPlugins)
+    expect(mockPlugins.shift()).toStrictEqual({ src: 'build/axios.js' })
   })
 })

--- a/packages/druxt/test/stores/druxt.test.js
+++ b/packages/druxt/test/stores/druxt.test.js
@@ -1,4 +1,5 @@
 import { createLocalVue } from '@vue/test-utils'
+import axios from 'axios'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { getMockCollection, getMockResource } from 'druxt-test-utils'
 import mockAxios from 'jest-mock-axios'
@@ -25,7 +26,7 @@ describe('DruxtStore', () => {
     store.app = { context: { error: jest.fn() } }
     DruxtStore({ store })
 
-    store.$druxt = new DruxtClient(baseUrl)
+    store.$druxt = new DruxtClient(baseUrl, { axios })
   })
 
   test('init', () => {

--- a/packages/router/test/components/DruxtRouter.test.js
+++ b/packages/router/test/components/DruxtRouter.test.js
@@ -1,6 +1,7 @@
 import 'regenerator-runtime/runtime'
-import mockAxios from 'jest-mock-axios'
 import { mount, createLocalVue } from '@vue/test-utils'
+import axios from 'axios'
+import mockAxios from 'jest-mock-axios'
 import Vuex from 'vuex'
 
 import { DruxtRouter, DruxtRouterStore } from '../../src'
@@ -47,7 +48,7 @@ describe('DruxtRouterComponent', () => {
     store = new Vuex.Store()
 
     DruxtRouterStore({ store })
-    store.$druxtRouter = () => new DruxtRouter(baseUrl)
+    store.$druxtRouter = () => new DruxtRouter(baseUrl, { axios })
   })
 
   test('Homepage', async () => {

--- a/packages/router/test/router.test.js
+++ b/packages/router/test/router.test.js
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import mockAxios from 'jest-mock-axios'
 
@@ -11,7 +12,7 @@ jest.mock('axios')
 describe('DruxtRouter', () => {
   beforeEach(() => {
     mockAxios.reset()
-    router = new DruxtRouter(baseUrl, {})
+    router = new DruxtRouter(baseUrl, { axios })
   })
 
   test('constructor', () => {

--- a/packages/router/test/stores/router.test.js
+++ b/packages/router/test/stores/router.test.js
@@ -1,4 +1,5 @@
 import { createLocalVue } from '@vue/test-utils'
+import axios from 'axios'
 import mockAxios from 'jest-mock-axios'
 import Vuex from 'vuex'
 
@@ -23,8 +24,8 @@ describe('DruxtRouterStore', () => {
     DruxtStore({ store })
     DruxtRouterStore({ store })
 
-    store.$druxt = new DruxtClient(baseUrl)
-    store.$druxtRouter = () => new DruxtRouter(baseUrl)
+    store.$druxt = new DruxtClient(baseUrl, { axios })
+    store.$druxtRouter = () => new DruxtRouter(baseUrl, { axios })
 
     store.app = { context: { error: jest.fn() }, store }
   })

--- a/packages/schema/test/schema.test.js
+++ b/packages/schema/test/schema.test.js
@@ -1,9 +1,11 @@
+import axios from 'axios'
+
 import { DruxtSchema } from '../src'
 
 jest.mock('axios')
 
 const baseUrl = 'https://demo-api.druxtjs.org'
-const options = {}
+const options = { axios }
 
 let schema
 

--- a/packages/schema/test/utils/schema.test.js
+++ b/packages/schema/test/utils/schema.test.js
@@ -1,11 +1,11 @@
-// import axios from 'axios'
+import axios from 'axios'
 import { DruxtSchema } from '../../src'
 import { Schema } from '../../src/utils/schema'
 
 jest.mock('axios')
 
 const baseURL = 'https://example.com'
-const options = {}
+const options = { axios }
 
 let druxtSchema
 

--- a/packages/views/test/stores/views.test.js
+++ b/packages/views/test/stores/views.test.js
@@ -1,4 +1,5 @@
 import { createLocalVue } from '@vue/test-utils'
+import axios from 'axios'
 import { DruxtClient, DruxtStore } from 'druxt'
 import mockAxios from 'jest-mock-axios'
 import Vuex from 'vuex'
@@ -26,7 +27,7 @@ describe('DruxtViewsStore', () => {
     DruxtStore({ store })
     DruxtViewsStore({ store })
 
-    store.$druxt = new DruxtClient('https://demo-api.druxtjs.org')
+    store.$druxt = new DruxtClient('https://demo-api.druxtjs.org', { axios })
 
     store.app = { context: { error: jest.fn() }, store }
   })

--- a/test/__mocks__/axios.js
+++ b/test/__mocks__/axios.js
@@ -48,12 +48,12 @@ mockAxios.get = jest.fn((url, options) => {
 })
 
 // Mock 'patch' requests.
-mockAxios.patch = jest.fn((url, data, options) => 
+mockAxios.patch = jest.fn((url, data, options) =>
   mockData(url, path.resolve('./test/__fixtures__/patch', md5(url), md5(JSON.stringify(data)) + '.json'))
 )
 
 // Mock 'post' requests.
-mockAxios.post = jest.fn((url, data, options) => 
+mockAxios.post = jest.fn((url, data, options) =>
   mockData(url, pathe.resolve('./test/__fixtures__/post', md5(url), md5(JSON.stringify(data)) + '.json'))
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,6 +2329,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nuxtjs/axios@npm:^5.13.6":
+  version: 5.13.6
+  resolution: "@nuxtjs/axios@npm:5.13.6"
+  dependencies:
+    "@nuxtjs/proxy": ^2.1.0
+    axios: ^0.21.1
+    axios-retry: ^3.1.9
+    consola: ^2.15.3
+    defu: ^5.0.0
+  checksum: 0af1cda9833dc6c37eb377a9313b421e030588d5a668b453259f68ff994967480c8b4928577751682fd8d3ca649391b05817003d172c1f62c6edb0aedd9eaf55
+  languageName: node
+  linkType: hard
+
 "@nuxtjs/proxy@npm:^2.1.0":
   version: 2.1.0
   resolution: "@nuxtjs/proxy@npm:2.1.0"
@@ -3174,6 +3187,15 @@ __metadata:
   bin:
     atob: bin/atob.js
   checksum: dfeeeb70090c5ebea7be4b9f787f866686c645d9f39a0d184c817252d0cf08455ed25267d79c03254d3be1f03ac399992a792edcd5ffb9c91e097ab5ef42833a
+  languageName: node
+  linkType: hard
+
+"axios-retry@npm:^3.1.9":
+  version: 3.1.9
+  resolution: "axios-retry@npm:3.1.9"
+  dependencies:
+    is-retry-allowed: ^1.1.0
+  checksum: 6c3418b19c2c3e4a50c1e2ef6678964283c6648f20595fbc8fec7db21a9274cf29f0af0a76308d2f3fcfe6c3e1d2956aa0cfc76e845dbcec514d1a4ba613d413
   languageName: node
   linkType: hard
 
@@ -4958,7 +4980,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "druxt@workspace:packages/druxt"
   dependencies:
-    axios: ^0.21.1
+    "@nuxtjs/axios": ^5.13.6
     core-js: ^3.16.1
     deepmerge: ^4.2.2
     drupal-jsonapi-params: ^1.2.1
@@ -6741,6 +6763,13 @@ __metadata:
     call-bind: ^1.0.2
     has-tostringtag: ^1.0.0
   checksum: 362399b33535bc8f386d96c45c9feb04cf7f8b41c182f54174c1a45c9abbbe5e31290bbad09a458583ff6bf3b2048672cdb1881b13289569a7c548370856a652
+  languageName: node
+  linkType: hard
+
+"is-retry-allowed@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "is-retry-allowed@npm:1.2.0"
+  checksum: 50d700a89ae31926b1c91b3eb0104dbceeac8790d8b80d02f5c76d9a75c2056f1bb24b5268a8a018dead606bddf116b2262e5ac07401eb8b8783b266ed22558d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,19 +2329,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxtjs/axios@npm:^5.13.6":
-  version: 5.13.6
-  resolution: "@nuxtjs/axios@npm:5.13.6"
-  dependencies:
-    "@nuxtjs/proxy": ^2.1.0
-    axios: ^0.21.1
-    axios-retry: ^3.1.9
-    consola: ^2.15.3
-    defu: ^5.0.0
-  checksum: 0af1cda9833dc6c37eb377a9313b421e030588d5a668b453259f68ff994967480c8b4928577751682fd8d3ca649391b05817003d172c1f62c6edb0aedd9eaf55
-  languageName: node
-  linkType: hard
-
 "@nuxtjs/proxy@npm:^2.1.0":
   version: 2.1.0
   resolution: "@nuxtjs/proxy@npm:2.1.0"
@@ -3190,21 +3177,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios-retry@npm:^3.1.9":
-  version: 3.1.9
-  resolution: "axios-retry@npm:3.1.9"
-  dependencies:
-    is-retry-allowed: ^1.1.0
-  checksum: 6c3418b19c2c3e4a50c1e2ef6678964283c6648f20595fbc8fec7db21a9274cf29f0af0a76308d2f3fcfe6c3e1d2956aa0cfc76e845dbcec514d1a4ba613d413
-  languageName: node
-  linkType: hard
-
 "axios@npm:^0.21.1":
   version: 0.21.1
   resolution: "axios@npm:0.21.1"
   dependencies:
     follow-redirects: ^1.10.0
   checksum: c87915fa0b18c15c63350112b6b3563a3e2ae524d7707de0a73d2e065e0d30c5d3da8563037bc29d4cc1b7424b5a350cb7274fa52525c6c04a615fe561c6ab11
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.21.4":
+  version: 0.21.4
+  resolution: "axios@npm:0.21.4"
+  dependencies:
+    follow-redirects: ^1.14.0
+  checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
   languageName: node
   linkType: hard
 
@@ -4980,7 +4967,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "druxt@workspace:packages/druxt"
   dependencies:
-    "@nuxtjs/axios": ^5.13.6
+    axios: ^0.21.4
     core-js: ^3.16.1
     deepmerge: ^4.2.2
     drupal-jsonapi-params: ^1.2.1
@@ -4989,6 +4976,8 @@ __metadata:
     scule: ^0.2.0
     vue: ^2.6.14
     vuex: ^3.6.2
+  peerDependencies:
+    "@nuxtjs/axios": ^5.13.6
   dependenciesMeta:
     core-js:
       optional: true
@@ -5750,6 +5739,16 @@ __metadata:
     debug:
       optional: true
   checksum: 7381a55bdc6951c5c1ab73a8da99d9fa4c0496ce72dba92cd2ac2babe0e3ebde9b81c5bca889498ad95984bc773d713284ca2bb17f1b1e1416e5f6531e39a488
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.0":
+  version: 1.14.4
+  resolution: "follow-redirects@npm:1.14.4"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: d4ce74cf5c6f363168b97e706b914eb9ffb6bf4d4c6d8f8330b93088d9b90e566611ddbcf0e42c8ed5fd17598dfeda1d19230d3e9d6d6c6b4d1c10ec3a0b99be
   languageName: node
   linkType: hard
 
@@ -6763,13 +6762,6 @@ __metadata:
     call-bind: ^1.0.2
     has-tostringtag: ^1.0.0
   checksum: 362399b33535bc8f386d96c45c9feb04cf7f8b41c182f54174c1a45c9abbbe5e31290bbad09a458583ff6bf3b2048672cdb1881b13289569a7c548370856a652
-  languageName: node
-  linkType: hard
-
-"is-retry-allowed@npm:^1.1.0":
-  version: 1.2.0
-  resolution: "is-retry-allowed@npm:1.2.0"
-  checksum: 50d700a89ae31926b1c91b3eb0104dbceeac8790d8b80d02f5c76d9a75c2056f1bb24b5268a8a018dead606bddf116b2262e5ac07401eb8b8783b266ed22558d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds support for custom Axios instance in the DruxtClient
Adds dependency on @nuxtjs/axios module in the Nuxt module.

<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/64"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

