### PR TITLE
Adding Gitpod's prebuild automation rules

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,3 +5,22 @@ vscode:
   extensions:
     - dbaeumer.vscode-eslint
     - octref.vetur
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true


### PR DESCRIPTION
This PR updates `.gitpod.yml` to run prebuilds automatically for every branch, fork, etc.

The missing step is configuring Gitpod Bot to have access to the repo, follow these instructions - https://github.com/apps/gitpod-io