### PR TITLE
fix(#145): change `nuxt-edge` to `nuxt`

### DIFF
--- a/examples/nuxt/druxt-site/package.json
+++ b/examples/nuxt/druxt-site/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "druxt-site": "link:../../../packages/druxt-site",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   }
 }


### PR DESCRIPTION
Swaps `nuxt-edge` for `nuxt`, as the latest `-edge` seems to be missing from the npm registry(?)

<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/146"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Fixed #145
