### PR TITLE
feat: add default Site layout and theme settings

### DIFF
--- a/.changeset/modern-tigers-press.md
+++ b/.changeset/modern-tigers-press.md
@@ -1,0 +1,5 @@
+---
+"druxt-site": minor
+---
+
+Add default theme option and fallback to DruxtSite component

--- a/.changeset/old-parrots-shave.md
+++ b/.changeset/old-parrots-shave.md
@@ -1,0 +1,5 @@
+---
+"druxt-site": minor
+---
+
+Added default layout

--- a/docs/content/modules/site/README.md
+++ b/docs/content/modules/site/README.md
@@ -33,6 +33,22 @@ Using Drupal's built in Entity display modes and Field formatter system, Views, 
    }
    ```
 
+### Options
+
+- `druxt.site.layout`
+
+  Type: `boolean`  
+  Default: `true`
+
+  Adds a default layout if no default layout has been provided.
+
+- `druxt.router.theme`
+
+  Type: `string`  
+
+  Sets the default theme to be used by the DruxtSite component. Theme can be overridden by the `theme` property on the component.  
+  If no value is provided, a fallback value will be determined from the JSON:API.
+
 * * *
 
 ## Vue.js components

--- a/examples/nuxt/druxt-site/layouts/default.vue
+++ b/examples/nuxt/druxt-site/layouts/default.vue
@@ -1,3 +1,0 @@
-<template>
-  <DruxtSite theme="umami" />
-</template>

--- a/examples/nuxt/druxt-site/nuxt.config.js
+++ b/examples/nuxt/druxt-site/nuxt.config.js
@@ -8,6 +8,7 @@ export default {
   druxt: {
     baseUrl,
     entity: { components: { fields: false } },
-    router: { pages: false }
+    router: { pages: false },
+    site: { theme: 'umami' }
   },
 }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -13,7 +13,8 @@
       "require": "./dist/druxt-site.ssr.js",
       "import": "./dist/druxt-site.esm.js"
     },
-    "./components/*": "./dist/components/*"
+    "./components/*": "./dist/components/*",
+    "./layouts/*": "./dist/layouts/*"
   },
   "main": "dist/druxt-site.ssr.js",
   "module": "dist/druxt-site.esm.js",

--- a/packages/site/src/layouts/default.vue
+++ b/packages/site/src/layouts/default.vue
@@ -1,0 +1,3 @@
+<template>
+  <DruxtSite />
+</template>

--- a/packages/site/src/nuxtModule.js
+++ b/packages/site/src/nuxtModule.js
@@ -1,4 +1,5 @@
-import { join } from 'path'
+import { existsSync } from 'fs'
+import { join, resolve } from 'path'
 
 /**
  * Nuxt module function to install Druxt Site.
@@ -10,7 +11,18 @@ import { join } from 'path'
  *
  * @param {ModuleOptions} moduleOptions - The Nuxt.js module options.
  */
-const DruxtSiteNuxtModule = function () {
+const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
+  // Set default options.
+  const options = {
+    baseUrl: moduleOptions.baseUrl,
+    ...(this.options || {}).druxt || {},
+    site: {
+      layout: true,
+      ...((this.options || {}).druxt || {}).site,
+      ...moduleOptions,
+    },
+  }
+
   // Register components directories.
   this.nuxt.hook('components:dirs', dirs => {
     dirs.push({ path: join(__dirname, 'components') })
@@ -47,6 +59,11 @@ const DruxtSiteNuxtModule = function () {
 
   // Enable Vuex Store.
   this.options.store = true
+
+  // Add default layout.
+  if (!(await existsSync(resolve(this.options.srcDir, this.options.dir.layouts))) && options.site.layout) {
+    this.addLayout(resolve(__dirname, './layouts/default.vue'), 'default')
+  }
 }
 
 DruxtSiteNuxtModule.meta = require('../package.json')

--- a/packages/site/src/nuxtModule.js
+++ b/packages/site/src/nuxtModule.js
@@ -16,6 +16,10 @@ const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
   const options = {
     baseUrl: moduleOptions.baseUrl,
     ...(this.options || {}).druxt || {},
+    menu: {
+      jsonApiMenuItems: true,
+      ...((this.options || {}).druxt || {}).menu,
+    },
     site: {
       layout: true,
       ...((this.options || {}).druxt || {}).site,
@@ -28,23 +32,9 @@ const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
     dirs.push({ path: join(__dirname, 'components') })
   })
 
-  // Enable JSON:API Menu items by default.
-  if (typeof ((this.options.druxt || {}).menu || {}).jsonApiMenuItems === 'undefined') {
-    this.options.druxt.menu = {
-      ...this.options.druxt.menu,
-      ...{ jsonApiMenuItems: true }
-    }
-  }
-
-  // Setup proxy for 'sites/default/files'.
-  if (typeof this.options.proxy === 'undefined') {
-    this.options.proxy = [this.options.druxt.baseUrl + '/sites/default/files']
-  }
-
-  // Add Nuxt.js modules.
-  const modules = [
-    '@nuxtjs/proxy',
-    'druxt',
+  // Add Druxt modules.
+  this.addModule(['druxt', options])
+  const druxtModules = [
     'druxt-blocks',
     'druxt-breadcrumb',
     'druxt-entity',
@@ -53,9 +43,15 @@ const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
     'druxt-schema',
     'druxt-views'
   ]
-  for (const key in modules) {
-    this.addModule(modules[key])
+  for (const module of druxtModules) {
+    this.addModule([module, { baseUrl: options.baseUrl, ...options[module.split('-')[1]] || {}}])
   }
+
+  // Setup proxy for 'sites/default/files'.
+  if (typeof this.options.proxy === 'undefined') {
+    this.options.proxy = [options.baseUrl + '/sites/default/files']
+  }
+  this.addModule('@nuxtjs/proxy')
 
   // Enable Vuex Store.
   this.options.store = true

--- a/packages/site/test/components/DruxtSite.test.js
+++ b/packages/site/test/components/DruxtSite.test.js
@@ -15,6 +15,7 @@ let store
 
 const mountComponent = (pending, options) => {
   const mocks = {
+    $druxt: { settings: {} },
     $fetchState: { pending }
   }
   const propsData = { theme: 'umami' }

--- a/packages/site/test/nuxtModule.test.js
+++ b/packages/site/test/nuxtModule.test.js
@@ -1,6 +1,7 @@
 import { DruxtSiteNuxtModule } from '../src/nuxtModule'
 
 const mock = {
+  addLayout: jest.fn(),
   addModule: jest.fn(),
   addPlugin: jest.fn(),
   addTemplate: jest.fn(),
@@ -19,11 +20,15 @@ const mock = {
 jest.mock('druxt-schema')
 
 describe('DruxtJS Site module', () => {
-  test('Nuxt module', () => {
-    mock.options = { druxt: {} }
+  test('Nuxt module', async () => {
+    mock.options = {
+      dir: { layouts: 'layouts' },
+      druxt: {},
+      srcDir: __dirname,
+    }
 
     // Call DruxtSite module.
-    mock.DruxtSiteNuxtModule()
+    await mock.DruxtSiteNuxtModule()
 
     // Expect 9 modules to be added.
     expect(mock.addModule).toHaveBeenCalledTimes(9)

--- a/test/__fixtures__/get/7a748bd9d861469c22ca962ae6f783b0.json
+++ b/test/__fixtures__/get/7a748bd9d861469c22ca962ae6f783b0.json
@@ -1,0 +1,34 @@
+{
+  "jsonapi": {
+    "version": "1.0",
+    "meta": {
+      "links": {
+        "self": {
+          "href": "http://jsonapi.org/format/1.0/"
+        }
+      }
+    }
+  },
+  "data": [
+    {
+      "type": "block--block",
+      "id": "a5e29a4e-cf00-4b84-b311-66e3b1e5e705",
+      "links": {
+        "self": {
+          "href": "https://demo-api.druxtjs.org/en/jsonapi/block/block/a5e29a4e-cf00-4b84-b311-66e3b1e5e705"
+        }
+      },
+      "attributes": {
+        "theme": "claro"
+      }
+    }
+  ],
+  "links": {
+    "next": {
+      "href": "https://demo-api.druxtjs.org/en/jsonapi/block/block?filter%5Bplugin%5D=system_main_block&page%5Boffset%5D=1&page%5Blimit%5D=1&fields%5Bblock--block%5D=theme"
+    },
+    "self": {
+      "href": "https://demo-api.druxtjs.org/en/jsonapi/block/block?fields%5Bblock--block%5D=theme&filter%5Bplugin%5D=system_main_block&page%5Blimit%5D=1"
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Adds a default layout and option, on by default if there's no layouts in the codebase: `druxt.site.layout`
- Adds default theme option and fallback for the DruxtSite component: `druxt.site.theme`
- Updates the Site module settings for better module level settings.
- Resolves #285 
- Resolves #98 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/286"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

