### PR TITLE
feat(#292): set `pages` default based on `pages/` directory

### DIFF
--- a/.changeset/afraid-coins-smash.md
+++ b/.changeset/afraid-coins-smash.md
@@ -1,0 +1,5 @@
+---
+"druxt-router": minor
+---
+
+Set router `pages` option default based on presence of `pages/` directory.

--- a/.changeset/clever-shrimps-vanish.md
+++ b/.changeset/clever-shrimps-vanish.md
@@ -3,3 +3,10 @@
 ---
 
 Moved Nuxt module to `druxt-router/nuxt`
+
+⚠ Potential breaking change
+
+```diff
+-modules: ['druxt-router']
++modules: ['druxt-router/nuxt']
+```

--- a/.changeset/clever-shrimps-vanish.md
+++ b/.changeset/clever-shrimps-vanish.md
@@ -1,0 +1,5 @@
+---
+"druxt-router": minor
+---
+
+Moved Nuxt module to `druxt-router/nuxt`

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ package-lock.json
 # Dist folders
 bin
 dist
+packages/*/nuxt
 
 # Coverage reports
 coverage

--- a/docs/content/modules/router/README.md
+++ b/docs/content/modules/router/README.md
@@ -23,7 +23,7 @@ description: Drupal router for Nuxt, powered by the Drupal Decoupled Router modu
 2. Add the module to `nuxt.config.js`:
    ```js
    export default {
-     modules: ['druxt-router'],
+     modules: ['druxt-router/nuxt'],
    }
    ```
 
@@ -32,9 +32,9 @@ description: Drupal router for Nuxt, powered by the Drupal Decoupled Router modu
 - `druxt.router.pages`
 
   Type: `boolean`  
-  Default: `true`
+  Default: `true` if **pages/** directory exists, else `false`
 
-  Controls whether the Nuxt `pages/` directory is used to generate routes.
+  Controls whether the Nuxt **pages/** directory is used to generate routes.
 
 - `druxt.router.wildcard`
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "changeset": "changeset",
     "clean": "yarn clean:dist && yarn clean:docs",
     "clean:docs": "rimraf docs/content/api || true",
-    "clean:dist": "rimraf packages/*/dist || true",
+    "clean:dist": "rimraf packages/*/dist packages/*/nuxt || true",
     "dev": "siroc dev",
     "lint": "eslint --ext .js,.vue packages/*/src",
     "lint:commit": "commitlint",

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -29,18 +29,12 @@ Add module to `nuxt.config.js`
 
 ```js
 module.exports = {
-  modules: [
-    ...
-    'druxt-router'
-  ],
-
+  modules: ['druxt-router/nuxt'],
   druxt: {
     baseUrl: 'https://demo-api.druxtjs.org'
   }
 }
 ```
-
-Ensure you have activated the [Nuxt Vuex store](https://nuxtjs.org/guide/vuex-store/).
 
 ## Options
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,12 +31,14 @@
       "require": "./dist/druxt-router.ssr.js",
       "import": "./dist/druxt-router.esm.js"
     },
-    "./components/*": "./dist/components/*"
+    "./components/*": "./dist/components/*",
+    "./nuxt": "./nuxt/index.js"
   },
   "main": "dist/druxt-router.ssr.js",
   "module": "dist/druxt-router.esm.js",
   "files": [
     "dist",
+    "nuxt",
     "templates"
   ],
   "dependencies": {

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -1,27 +1,3 @@
-import { DruxtRouterNuxtModule } from './nuxtModule'
-
-/**
- * The Nuxt.js module function.
- *
- * Installs the module functionality in a Nuxt application.
- *
- * @type {Function}
- * @exports default
- * @name DruxtRouterNuxtModule
- * @see {@link ./nuxtModule|DruxtRouterNuxtModule}
- *
- * @example <caption>nuxt.config.js</caption> @lang js
- * module.exports = {
- *   modules: [
- *     'druxt-router'
- *   ],
- *   druxt: {
- *     baseUrl: 'https://demo-api.druxtjs.org'
- *   }
- * }
- */
-export default DruxtRouterNuxtModule
-
 /**
  * The DruxtRouter class.
  *
@@ -81,4 +57,3 @@ export { DruxtRouterStore } from './stores/router'
   * </script>
   */
  export { DruxtRouterMixin } from './mixins/router'
- 

--- a/packages/router/src/nuxt/index.js
+++ b/packages/router/src/nuxt/index.js
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs'
 import { join, resolve } from 'path'
 
 /**
@@ -14,9 +15,7 @@ import { join, resolve } from 'path'
  * @example @lang js
  * // `nuxt.config.js`
  * module.exports = {
- *   modules: [
- *     'druxt-router'
- *   ],
+ *   buildModules: ['druxt-router/nuxt'],
  *   druxt: {
  *     baseUrl: 'https://demi-api.druxtjs.org'
  *   }
@@ -26,13 +25,13 @@ import { join, resolve } from 'path'
  * @property {string} options.druxt.baseUrl - Base URL of Drupal JSON:API backend.
  * @property {string} options.druxt.router.component - File to custom Router component.
  */
-const DruxtRouterNuxtModule = function (moduleOptions = {}) {
+const DruxtRouterNuxtModule = async function (moduleOptions = {}) {
   // Set default options.
   const options = {
     baseUrl: moduleOptions.baseUrl,
     ...(this.options || {}).druxt || {},
     router: {
-      pages: true,
+      pages: (await existsSync(resolve(this.options.srcDir, this.options.dir.pages))),
       wildcard: true,
       ...((this.options || {}).druxt || {}).router,
       ...moduleOptions,
@@ -41,7 +40,7 @@ const DruxtRouterNuxtModule = function (moduleOptions = {}) {
 
   // Register components directories.
   this.nuxt.hook('components:dirs', dirs => {
-    dirs.push({ path: join(__dirname, 'components') })
+    dirs.push({ path: join(__dirname, '../dist/components') })
   })
 
   // Add Druxt router custom wildcard route.
@@ -89,4 +88,4 @@ const DruxtRouterNuxtModule = function (moduleOptions = {}) {
 
 DruxtRouterNuxtModule.meta = require('../package.json')
 
-export { DruxtRouterNuxtModule }
+export default DruxtRouterNuxtModule

--- a/packages/router/test/nuxt/index.test.js
+++ b/packages/router/test/nuxt/index.test.js
@@ -1,4 +1,4 @@
-import { DruxtRouterNuxtModule } from '../src/nuxtModule'
+import DruxtRouterNuxtModule from '../../nuxt'
 
 const mock = {
   addPlugin: jest.fn(),
@@ -22,25 +22,29 @@ const mock = {
   DruxtRouterNuxtModule
 }
 
-test('Nuxt module', () => {
+test('Nuxt module', async () => {
   mock.options = {
-    druxt: {}
+    druxt: {},
+    srcDir: __dirname,
+    dir: { pages: 'pages' }
   }
-  mock.DruxtRouterNuxtModule()
+
+  mock.options.druxt.router = { pages: true }
+  await mock.DruxtRouterNuxtModule()
   expect(mock.addPlugin).toHaveBeenCalledTimes(2)
   expect(mock.addTemplate).toHaveBeenCalledTimes(1)
   expect(mock.nuxt.hook).toHaveBeenCalledTimes(1)
   jest.clearAllMocks()
 
   mock.options.druxt.router = { wildcard: false }
-  mock.DruxtRouterNuxtModule()
+  await mock.DruxtRouterNuxtModule()
   expect(mock.addPlugin).toHaveBeenCalledTimes(2)
   expect(mock.addTemplate).toHaveBeenCalledTimes(0)
   expect(mock.nuxt.hook).toHaveBeenCalledTimes(1)
   jest.clearAllMocks()
 
   mock.options.druxt.router = { pages: false }
-  mock.DruxtRouterNuxtModule()
+  await mock.DruxtRouterNuxtModule()
   expect(mock.addPlugin).toHaveBeenCalledTimes(2)
   expect(mock.addTemplate).toHaveBeenCalledTimes(1)
   expect(mock.nuxt.hook).toHaveBeenCalledTimes(2)

--- a/packages/site/src/nuxtModule.js
+++ b/packages/site/src/nuxtModule.js
@@ -40,7 +40,7 @@ const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
     'druxt-breadcrumb',
     'druxt-entity',
     'druxt-menu',
-    'druxt-router',
+    'druxt-router/nuxt',
     'druxt-schema',
     'druxt-views'
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Moved Nuxt module to `druxt-router/nuxt`
- Added check for `pages/` directory
- Resolves #292 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

