### PR TITLE
fix(#297): add conditional defaults to stop errors

### DIFF
--- a/.changeset/forty-sheep-retire.md
+++ b/.changeset/forty-sheep-retire.md
@@ -1,0 +1,5 @@
+---
+"druxt-views": patch
+---
+
+Fixed errors when no props provided to component

--- a/packages/views/src/components/DruxtView.vue
+++ b/packages/views/src/components/DruxtView.vue
@@ -201,7 +201,7 @@ export default {
      * @type {object}
      */
     display() {
-      if (!(((this.view || {}).data || {}).attributes || {}).display) return false
+      if (!(((this.view || {}).data || {}).attributes || {}).display) return {}
 
       if (this.display_id === 'default') return this.view.data.attributes.display[this.display_id]
 
@@ -228,7 +228,7 @@ export default {
     headers() {
       if (!this.display) return []
 
-      return this.display.display_options.header
+      return (this.display.display_options || {}).header || []
     },
 
     /**
@@ -237,7 +237,7 @@ export default {
      * @type {string}
      */
     mode() {
-      if (!this.display) return 'default'
+      if (!this.display || !this.display.display_options) return 'default'
 
       if (!this.display.display_options.row.type.includes('entity:')) return 'default'
 
@@ -519,7 +519,7 @@ export default {
       // Results.
       scopedSlots.results = (attrs) => {
         if (!this.results.length) {
-          return Object.values(this.display.display_options.empty)
+          return Object.values(((this.display || {}).display_options || {}).empty || {})
             .filter((o) => o.plugin_id === 'text_custom')
             .map((empty) => {
               return h('div', { domProps: { innerHTML: empty.content } })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Added conditional defaults to prevent errors when no props provided to DruxtView component
- Fixed #297

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

