### PR TITLE
feat(#310): add default for nuxt components option

### DIFF
--- a/.changeset/sweet-numbers-help.md
+++ b/.changeset/sweet-numbers-help.md
@@ -1,0 +1,5 @@
+---
+"druxt": minor
+---
+
+Enabled Components auto-discovery by default

--- a/examples/nuxt/druxt-site/nuxt.config.js
+++ b/examples/nuxt/druxt-site/nuxt.config.js
@@ -3,12 +3,10 @@ export default {
   target: 'static',
   generate: { routes: ['/'] },
   telemetry: true,
-  components: true,
   modules: ['druxt-site'],
   druxt: {
     baseUrl,
     entity: { components: { fields: false } },
-    router: { pages: false },
     site: { theme: 'umami' }
   },
 }

--- a/packages/druxt/src/nuxtModule.js
+++ b/packages/druxt/src/nuxtModule.js
@@ -52,6 +52,9 @@ const DruxtNuxtModule = function (moduleOptions = {}) {
   // Enable Vuex Store.
   this.options.store = true
 
+  // Enable components auto-discovery by default.
+  this.options.components = this.options.components ?? true
+
   // Add CLI badge.
   this.options.cli.badgeMessages.push(`${chalk.bold('Druxt API:')} ${chalk.blue.underline(options.baseUrl + options.endpoint)}`)
 }

--- a/packages/druxt/test/nuxtModule.test.js
+++ b/packages/druxt/test/nuxtModule.test.js
@@ -47,4 +47,19 @@ describe('DruxtJS Nuxt module', () => {
     // Expect addPlugin to have been called with options.
     expect(mock.addPlugin).toHaveBeenCalledWith(expect.objectContaining({ options }))
   })
+
+  test('Default options', () => {
+    // Expect:
+    // - Components enabled.
+    // - Vuex store enabled.
+    DruxtNuxtModule.call(mock)
+    expect(mock.options.components).toBe(true)
+    expect(mock.options.store).toBe(true)
+
+    // Expect:
+    // - Components disbaled.
+    mock.options.components = false
+    DruxtNuxtModule.call(mock)
+    expect(mock.options.components).toBe(false)
+  })
 })

--- a/packages/site/src/nuxtModule.js
+++ b/packages/site/src/nuxtModule.js
@@ -48,19 +48,14 @@ const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
     this.addModule([module, { baseUrl: options.baseUrl, ...options[module.split('-')[1]] || {}}])
   }
 
-  // Setup proxy for 'sites/default/files'.
-  if (typeof this.options.proxy === 'undefined') {
-    this.options.proxy = [options.baseUrl + '/sites/default/files']
-  }
-  this.addModule('@nuxtjs/proxy')
-
-  // Enable Vuex Store.
-  this.options.store = true
-
   // Add default layout.
   if (!(await existsSync(resolve(this.options.srcDir, this.options.dir.layouts))) && options.site.layout) {
     this.addLayout(resolve(__dirname, './layouts/default.vue'), 'default')
   }
+
+  // Setup proxy for 'sites/default/files'.
+  this.options.proxy = this.options.proxy ?? [options.baseUrl + '/sites/default/files']
+  this.addModule('@nuxtjs/proxy')
 
   // Nuxt Storybook.
   this.nuxt.hook('storybook:config', async ({ stories }) => {

--- a/packages/site/test/nuxtModule.test.js
+++ b/packages/site/test/nuxtModule.test.js
@@ -22,7 +22,7 @@ const mock = {
 jest.mock('druxt-schema')
 
 describe('DruxtJS Site module', () => {
-  test('Nuxt module', () => {
+  test('Nuxt module', async () => {
     mock.options = {
       dir: { layouts: 'layouts' },
       druxt: {},
@@ -30,7 +30,7 @@ describe('DruxtJS Site module', () => {
     }
 
     // Call DruxtSite module.
-    mock.DruxtSiteNuxtModule()
+    await mock.DruxtSiteNuxtModule()
 
     // Expect 9 modules to be added.
     expect(mock.addModule).toHaveBeenCalledTimes(9)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Enabled Nuxt components auto-discovery option by default.
- Resolves #310

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/316"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

