### PR TITLE
feat(#312): unwrap template injected components

### DIFF
--- a/.changeset/twenty-fireants-collect.md
+++ b/.changeset/twenty-fireants-collect.md
@@ -1,0 +1,5 @@
+---
+"druxt": minor
+---
+
+Changed template injected module components to not use a DruxtWrapper component by default.

--- a/docs/content/guide/theming.md
+++ b/docs/content/guide/theming.md
@@ -51,10 +51,10 @@ If there are no matching component names, a default `DruxtWrapper` component wil
 
 Most Druxt modules can have the default template overridden, allowing for full control of the default slot rendering.
 
-The available data provided to the template scope is deteremined by the relevant module.
+The available data provided to the template scope is determined by the relevant module.
 
 ```vue
-<DruxtEntity>
+<DruxtEntity v-bind="props">
   <template #default="{ entity }">
     <div>
       <h1>{{ entity.attributes.title }}</h1>
@@ -62,3 +62,13 @@ The available data provided to the template scope is deteremined by the relevant
   </template>
 </DruxtEntity>
 ```
+
+By default, a component using the default template will not be wrapped by a DruxtWrapper component. It is possible to enable the DruxtWrapper system by setting the `wrapper` property to `true`:
+
+```vue
+<DruxtBlock v-bind="props" :wrapper="true">
+  <template #default="{ block }">
+    // This will be wrapped by a DruxtBlock Wrapper component.
+  </template>
+</DruxtBlock>
+````

--- a/examples/nuxt/wrappers/README.md
+++ b/examples/nuxt/wrappers/README.md
@@ -1,0 +1,10 @@
+# wrappers
+
+This directory contains exaples of how to use Wrapper components and the wrapper property.
+
+
+## Setup
+
+```
+yarn && yarn dev
+```

--- a/examples/nuxt/wrappers/components/druxt/entity/node/Page.vue
+++ b/examples/nuxt/wrappers/components/druxt/entity/node/Page.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    This is a DruxtWrapper: DruxtEntityNodePage.vue
+    <h3>This is a theme component: DruxtEntityNodePage.vue</h3>
+    <slot />
   </div>
 </template>
 

--- a/examples/nuxt/wrappers/components/druxt/entity/node/Page.vue
+++ b/examples/nuxt/wrappers/components/druxt/entity/node/Page.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    This is a DruxtWrapper: DruxtEntityNodePage.vue
+  </div>
+</template>
+
+<script>
+export default {
+  druxt: {
+    query: {
+      schema: true
+    }
+  }
+}
+</script>

--- a/examples/nuxt/wrappers/nuxt.config.js
+++ b/examples/nuxt/wrappers/nuxt.config.js
@@ -1,0 +1,3 @@
+export default {
+  buildModules: [['druxt-entity', { baseUrl: 'https://demo-api.druxtjs.org' }]]
+}

--- a/examples/nuxt/wrappers/package.json
+++ b/examples/nuxt/wrappers/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "wrappers",
+  "scripts": {
+    "dev": "nuxt dev"
+  },
+  "packageManager": "yarn@3.0.0",
+  "dependencies": {
+    "druxt-entity": "link:../../../packages/druxt-entity",
+    "nuxt": "latest"
+  }
+}

--- a/examples/nuxt/wrappers/pages/index.vue
+++ b/examples/nuxt/wrappers/pages/index.vue
@@ -1,17 +1,49 @@
 <template>
   <div v-if="!$fetchState.pending">
+    <h1>DruxtWrapper examples</h1>
+    <blockquote>
+      The DruxtWrapper is a theming component that wraps the DruxtModule output.
+      <br />
+      The following examples demonstrate different ways it can be used.
+    </blockquote>
+
+    <hr />
+
+    <h2>DruxtEntity default</h2>
+    <p>This is the default behaviour, renders a theme component.</p>
+    <pre><code>&lt;DruxtEntity :type="type" :uuid="uuid" /&gt;</code></pre>
     <details>
-      <summary><strong>Wrapper: default</strong></summary>
+      <summary><strong>Output</strong></summary>
       <DruxtEntity :type="type" :uuid="uuid" />
     </details>
 
+    <hr />
+
+    <h2>DruxtEntity with wrapper disabled</h2>
+    <p>
+      This will ignore any available wrapper components and renders the default
+      output of the DruxtEntity module.
+    </p>
+    <pre><code>&lt;DruxtEntity :type="type" :uuid="uuid" :wrapper="false" /&gt;</code></pre>
     <details>
-      <summary><strong>Wrapper: false</strong></summary>
+      <summary><strong>Output</strong></summary>
       <DruxtEntity :type="type" :uuid="uuid" :wrapper="false" />
     </details>
 
+    <hr />
+
+    <h2>DruxtEntity using template injection, default wrapper</h2>
+    <p>
+      The value of the template will be the output of the component, wrapper
+      component is ignored.
+    </p>
+    <pre><code>&lt;DruxtEntity :type="type" :uuid="uuid"&gt;
+    &lt;template #default="{ entity }"&gt;
+      ...
+    &lt;/template&gt;
+  &lt;/DruxtEntity&gt;</code></pre>
     <details>
-      <summary><strong>Template injection / Wrapper: default</strong></summary>
+      <summary><strong>Output</strong></summary>
       <DruxtEntity :type="type" :uuid="uuid">
         <template #default="{ entity }">
           <pre><code>{{ JSON.stringify(entity, null, '  ') }}</code></pre>
@@ -19,8 +51,20 @@
       </DruxtEntity>
     </details>
 
+    <hr />
+
+    <h2>DruxtEntity using template injection with wrapper enabled</h2>
+    <p>
+      The value of the template will be the output of the default slot in a
+      wrapper component.
+    </p>
+    <pre><code>&lt;DruxtEntity :type="type" :uuid="uuid" :wrapper="true"&gt;
+    &lt;template #default="{ entity }"&gt;
+      ...
+    &lt;/template&gt;
+  &lt;/DruxtEntity&gt;</code></pre>
     <details>
-      <summary><strong>Template injection / Wrapper: true</strong></summary>
+      <summary><strong>Output</strong></summary>
       <DruxtEntity :type="type" :uuid="uuid" :wrapper="true">
         <template #default="{ entity }">
           <pre><code>{{ JSON.stringify(entity, null, '  ') }}</code></pre>

--- a/examples/nuxt/wrappers/pages/index.vue
+++ b/examples/nuxt/wrappers/pages/index.vue
@@ -1,0 +1,49 @@
+<template>
+  <div v-if="!$fetchState.pending">
+    <details>
+      <summary><strong>Wrapper: default</strong></summary>
+      <DruxtEntity :type="type" :uuid="uuid" />
+    </details>
+
+    <details>
+      <summary><strong>Wrapper: false</strong></summary>
+      <DruxtEntity :type="type" :uuid="uuid" :wrapper="false" />
+    </details>
+
+    <details>
+      <summary><strong>Template injection / Wrapper: default</strong></summary>
+      <DruxtEntity :type="type" :uuid="uuid">
+        <template #default="{ entity }">
+          <pre><code>{{ JSON.stringify(entity, null, '  ') }}</code></pre>
+        </template>
+      </DruxtEntity>
+    </details>
+
+    <details>
+      <summary><strong>Template injection / Wrapper: true</strong></summary>
+      <DruxtEntity :type="type" :uuid="uuid" :wrapper="true">
+        <template #default="{ entity }">
+          <pre><code>{{ JSON.stringify(entity, null, '  ') }}</code></pre>
+        </template>
+      </DruxtEntity>
+    </details>
+  </div>
+
+  <div v-else>Loading...</div>
+</template>
+
+<script>
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+
+export default {
+  async fetch() {
+    const query = new DrupalJsonApiParams().addPageLimit(1).addFields(this.type, ['id'])
+    this.uuid = (await this.$store.dispatch('druxt/getCollection', { type: this.type, query })).data[0].id
+  },
+
+  data: () => ({
+    uuid: null,
+    type: 'node--page'
+  })
+}
+</script>

--- a/packages/druxt/src/components/DruxtModule.vue
+++ b/packages/druxt/src/components/DruxtModule.vue
@@ -37,12 +37,25 @@ export default {
       default: null,
     },
 
+    /**
+     * The wrapper component configuration.
+     *
+     * Used to set the wrapper component, class, style and propsData.
+     *
+     * @example
+     * <DruxtModule
+     *   :wrapper="{
+     *     component: 'MyWrapper',
+     *     class: 'wrapper',
+     *     propsData: { foo: 'bar' }
+     *   }"
+     * />
+     *
+     * @type {(Boolean|Object)}
+     */
     wrapper: {
-      type: Object,
-      default: () => ({
-        component: 'div',
-        propsData: {},
-      })
+      type: [Boolean, Object],
+      default: () => undefined
     },
   },
 
@@ -154,12 +167,14 @@ export default {
      * @returns {Components}
      */
     getModuleComponents() {
+      // Ensure that the Druxt module component has `druxt.componentOptions`.
       if (!(this.$options.druxt || {}).componentOptions) {
         return []
       }
-
       const options = this.$options.druxt.componentOptions.call(this, this)
-      if (!options || !options.length) {
+
+      // Ensure that there available component options are returned.
+      if (!(options || []).length) {
         return []
       }
 
@@ -304,20 +319,27 @@ export default {
     const self = this
 
     const wrapperData = {
-      class: this.wrapper.class || undefined,
-      style: this.wrapper.style || undefined,
-      props: this.wrapper.propsData,
+      class: (this.wrapper || {}).class || undefined,
+      style: (this.wrapper || {}).style || undefined,
+      props: (this.wrapper || {}).propsData || undefined,
     }
 
     // Return only wrapper if fetch state is still pending.
     if (this.$fetchState.pending) {
-      return h(this.wrapper.component, wrapperData)
+      return h((this.wrapper || {}).component || 'div', wrapperData)
     }
 
-    // Return wrapped component.
+    // Prepare attributes.
     const attrs = { ...this.component.$attrs, ...this.$attrs }
     delete attrs['data-fetch-key']
-    return h(this.wrapper.component, wrapperData, [
+
+    // Unwrap default template based component if required.
+    if (this.$scopedSlots.default && !this.wrapper) {
+      this.component.is = 'DruxtWrapper'
+    }
+
+    // Return component.
+    return h((this.wrapper || {}).component || 'div', wrapperData, [
       h(this.component.is, {
         attrs,
         on: {

--- a/packages/druxt/src/components/DruxtModule.vue
+++ b/packages/druxt/src/components/DruxtModule.vue
@@ -110,7 +110,17 @@ export default {
     }
 
     // Build wrapper component object.
-    const options = this.getModuleComponents()
+    let options = []
+    const hasDefaultTemplate = !!(this.$vnode.data.scopedSlots || {}).default
+    // Load wrapper components if:
+    if (
+      // No default template and wrapper isn't false OR
+      (!hasDefaultTemplate && this.wrapper !== false) ||
+      // Default tempalte and wrapper is set
+      (hasDefaultTemplate && this.wrapper)
+    ) {
+      options = this.getModuleComponents()
+    }
     let component = {
       is: (((options.filter(o => o.global) || [])[0] || {}).name || 'DruxtWrapper'),
       options: options.map(o => o.name) || [],
@@ -334,7 +344,7 @@ export default {
     delete attrs['data-fetch-key']
 
     // Unwrap default template based component if required.
-    if (this.$scopedSlots.default && !this.wrapper) {
+    if ((this.$scopedSlots.default && !this.wrapper) || this.wrapper === false) {
       this.component.is = 'DruxtWrapper'
     }
 

--- a/packages/druxt/test/components/DruxtModule.test.js
+++ b/packages/druxt/test/components/DruxtModule.test.js
@@ -13,6 +13,7 @@ describe('DruxtModule component', () => {
     mocks = {
       $createElement: jest.fn(),
       $fetchState: { pending: false },
+      $options: { druxt: {} },
       $nuxt: {
         context: {
           isDev: false,
@@ -199,11 +200,19 @@ describe('DruxtModule component', () => {
   })
 
   test('custom default slot', async () => {
+    const customModule = {
+      extends: DruxtModule,
+      druxt: {}
+    }
+
     const scopedSlots = { default: jest.fn() }
-    const wrapper = mount(DruxtModule, { localVue, mocks, scopedSlots })
+    const wrapper = mount(customModule, { localVue, mocks, scopedSlots })
     await wrapper.vm.$options.fetch.call(wrapper.vm)
 
     wrapper.vm.getScopedSlots().default.call(wrapper.vm)
     expect(scopedSlots.default).toHaveBeenCalled()
+
+    await wrapper.setProps({ wrapper: true })
+    await wrapper.vm.$options.fetch.call(wrapper.vm)
   })
 })


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Changed template injected components to be unwrapped by default
- Resolves #312

Example:
```jsx
<template>
  <DruxtEntity v-bind="props">
    <template #default="{ entity }">
      // This would no longer be wrapped by DruxtEntityNode[Type], etc.
    </template>
  </DruxtyEntity>
</template>
```

This is a change to the current default behaviour, as a template injected component is currently wrapped. However in my usage I've found that this is not the desired default behaviour.

It's still possible to wrap a template injected component by setting a value to the `wrapper` property, either the standard Object values or `true`

Example:
```jsx
<template>
  <DruxtEntity v-bind="props" :wrapper="true">
    <template #default="{ entity }">
      // This would be wrapped by DruxtEntityNode[Type], etc.
    </template>
  </DruxtyEntity>
</template>
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/351"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

