### PR TITLE
feat(#384): make summary prop optional

### DIFF
--- a/.changeset/unlucky-papayas-pull.md
+++ b/.changeset/unlucky-papayas-pull.md
@@ -1,0 +1,5 @@
+---
+"druxt": minor
+---
+
+Make summary prop optional on DruxtDebug component

--- a/packages/druxt/src/components/DruxtDebug.vue
+++ b/packages/druxt/src/components/DruxtDebug.vue
@@ -21,7 +21,7 @@ export default {
      */
     summary: {
       type: String,
-      required: true,
+      default: 'Debug',
     },
   },
 
@@ -42,7 +42,9 @@ export default {
      *
      * @return {string}
      */
-    title: ({ module, summary }) => `[${module.$options._componentTag}] ${summary}`,
+    title: ({ module, summary }) => module.$options._componentTag
+      ? `[${module.$options._componentTag}] ${summary}`
+      : summary,
   },
 };
 </script>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Makes summary field optional, and defaults to "Debug".
- Resolves #384

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/385"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

