### PR TITLE
feat(#357): make $druxt plugin first

### DIFF
--- a/.changeset/funny-weeks-greet.md
+++ b/.changeset/funny-weeks-greet.md
@@ -1,0 +1,5 @@
+---
+"druxt": minor
+---
+
+Made the \$druxt plugin first to be available to all Druxt module plugins.

--- a/packages/druxt/src/index.js
+++ b/packages/druxt/src/index.js
@@ -1,4 +1,5 @@
-import { DruxtNuxtModule } from './nuxtModule'
+import { DruxtNuxtModule } from './nuxt'
+DruxtNuxtModule.meta = require('../package.json')
 
 /**
  * The JSON:API client used by the Druxt Nuxt plugin and DruxtStore.

--- a/packages/druxt/src/nuxt/index.js
+++ b/packages/druxt/src/nuxt/index.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import { join, resolve } from 'path'
-import meta from '../package.json'
+import meta from '../../package.json'
 
 /**
  * Nuxt module function to install Druxt.
@@ -103,8 +103,6 @@ const DruxtNuxtModule = function (moduleOptions = {}) {
   this.options.cli.badgeMessages.push(`${chalk.blue.bold('Druxt')} @ v${meta.version}`)
   this.options.cli.badgeMessages.push(`${chalk.bold('API:')} ${chalk.blue.underline(options.baseUrl + options.endpoint)}`)
 }
-
-DruxtNuxtModule.meta = meta
 
 export { DruxtNuxtModule }
 

--- a/packages/druxt/src/nuxt/index.js
+++ b/packages/druxt/src/nuxt/index.js
@@ -86,6 +86,23 @@ const DruxtNuxtModule = function (moduleOptions = {}) {
     options
   })
 
+  // Make the $druxt plugin the first to load.
+  const extendPlugins = this.options.extendPlugins
+  this.options.extendPlugins = (plugins) => {
+    // Run the user defined extendPlugins function if defined.
+    plugins = typeof extendPlugins === 'function' ? extendPlugins(plugins) : plugins
+
+    // Find the $druxt plugin.
+    const index = plugins.findIndex(({ src }) => src === `${this.options.buildDir}/druxt.js`)
+    const plugin = plugins[index]
+
+    // Move the $druxt plugin to first place.
+    plugins.splice(index, 1)
+    plugins.unshift(plugin)
+
+    return plugins
+  }
+
   // Add Vuex plugin.
   this.addPlugin({
     src: resolve(__dirname, '../templates/store.js'),

--- a/packages/druxt/test/nuxt/index.test.js
+++ b/packages/druxt/test/nuxt/index.test.js
@@ -64,6 +64,24 @@ describe('DruxtJS Nuxt module', () => {
     expect(mock.options.components).toBe(false)
   })
 
+  test('Plugin order', () => {
+    mock.options.buildDir = '.nuxt'
+
+    // Expect:
+    // - extendPlugins to be a function.
+    DruxtNuxtModule.call(mock)
+    expect(typeof mock.options.extendPlugins).toBe('function')
+
+    // Expect:
+    // - The plugins should have the $druxt plugin first.
+    const plugins = [
+      { src: `${mock.options.buildDir}/foobar.js` },
+      { src: `${mock.options.buildDir}/druxt.js` }
+    ]
+    let sorted = mock.options.extendPlugins(plugins)
+    expect(sorted[0].src).toBe(`${mock.options.buildDir}/druxt.js`)
+  })
+
   test('API Proxy', () => {
     // Enable API Proxy.
     mock.options.druxt = {

--- a/packages/druxt/test/nuxt/index.test.js
+++ b/packages/druxt/test/nuxt/index.test.js
@@ -1,4 +1,4 @@
-import { DruxtNuxtModule } from '../src/nuxtModule'
+import DruxtNuxtModule from '../../src'
 
 const options = {
   baseUrl: 'https://demo-api.druxtjs.org',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Moved the Nuxt module to the `src/nuxt` directory
- Added extendPlugins to make the $druxt plugin the first loaded
- Resolves #357

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/404"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

