### PR TITLE
feat(#429): add id and uuid watch

### DIFF
--- a/.changeset/fast-bottles-yell.md
+++ b/.changeset/fast-bottles-yell.md
@@ -1,0 +1,5 @@
+---
+"druxt-blocks": minor
+---
+
+feat(#429): Added watch for ID and UUID to the DruxtBlock component.

--- a/packages/blocks/src/components/DruxtBlock.vue
+++ b/packages/blocks/src/components/DruxtBlock.vue
@@ -70,6 +70,16 @@ export default {
     block: ({ resource }) => (resource || {}).data,
   },
 
+  watch: {
+    id() {
+      this.$fetch()
+    },
+
+    uuid() {
+      this.$fetch()
+    }
+  },
+
   methods: {
     /**
      * Maps Vuex action to methods.

--- a/packages/blocks/test/components/DruxtBlock.test.js
+++ b/packages/blocks/test/components/DruxtBlock.test.js
@@ -146,4 +146,15 @@ describe('Component - DruxtBlock', () => {
       block: wrapper.vm.block,
     })
   })
+
+  test('watch - props $fetch', async () => {
+    const $fetch = jest.fn()
+    expect($fetch).toHaveBeenCalledTimes(0)
+
+    DruxtBlock.watch.id.call({ $fetch })
+    expect($fetch).toHaveBeenCalledTimes(1)
+
+    DruxtBlock.watch.uuid.call({ $fetch })
+    expect($fetch).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Adds a watch for ID and UUID to the DruxtBlock component; This allows reactive storybook integration.
- Resolves #429

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/430"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

