### PR TITLE
fix(#438): add escaping to story title

### DIFF
--- a/.changeset/wild-humans-cough.md
+++ b/.changeset/wild-humans-cough.md
@@ -1,0 +1,5 @@
+---
+"druxt-entity": patch
+---
+
+fix(#438): fixed DruxtEntity and DruxtEntityForm stories.

--- a/packages/entity/templates/druxt-entity-form.instance.stories.js
+++ b/packages/entity/templates/druxt-entity-form.instance.stories.js
@@ -36,7 +36,7 @@ export default {
       options: [<%= (options.entities || []).map((o) => `'${o.id}'`).join(', ') %>],
       control: {
         type: 'select',
-        labels: Object.fromEntries([<%= (options.entities || []).map((o) => `['${o.id}', "${o.title} (${o.id})"]`).join(', ') %>])
+        labels: Object.fromEntries([<%= (options.entities || []).map((o) => `['${o.id}', '${o.title.replace(/\'/g, "\\'")} (${o.id})']`).join(', ') %>])
       },
     },
     value: {

--- a/packages/entity/templates/druxt-entity.instance.stories.js
+++ b/packages/entity/templates/druxt-entity.instance.stories.js
@@ -32,7 +32,7 @@ export default {
       options: [<%= (options.entities || []).map((o) => `'${o.id}'`).join(', ') %>],
       control: {
         type: 'select',
-        labels: Object.fromEntries([<%= (options.entities || []).map((o) => `['${o.id}', "${o.title} (${o.id})"]`).join(', ') %>])
+        labels: Object.fromEntries([<%= (options.entities || []).map((o) => `['${o.id}', '${o.title.replace(/\'/g, "\\'")} (${o.id})']`).join(', ') %>])
       },
       type: {
         required: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Escapes Entity and Entity form titles for UUID in Storybook.
- Resolves #438

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/439"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

