### PR TITLE
fix(Broken links in API documentation to packages #477): remove html …

### DIFF
--- a/packages/blocks/src/components/blocks/DruxtBlockBlockContent.vue
+++ b/packages/blocks/src/components/blocks/DruxtBlockBlockContent.vue
@@ -52,7 +52,7 @@ export default {
      *
      * @type {object}
      *
-     * @see {@link https://druxt.github.io/druxt-entity/api/components/DruxtEntity.html|DruxtEntity}
+     * @see {@link https://druxt.github.io/druxt-entity/api/components/DruxtEntity|DruxtEntity}
      */
     propsData: ({ $fetchState, $store, block }) => {
       if ($fetchState.pending) return false

--- a/packages/breadcrumb/src/components/blocks/DruxtBlockSystemBreadcrumbBlock.vue
+++ b/packages/breadcrumb/src/components/blocks/DruxtBlockSystemBreadcrumbBlock.vue
@@ -17,7 +17,7 @@ import { DruxtBlocksBlockMixin } from 'druxt-blocks'
  *   uuid="59121e44-e21b-4f53-b009-5225cd630145"
  * />
  *
- * @see {@link https://blocks.druxtjs.org/api/components/DruxtBlock.html|DruxtBlock}
+ * @see {@link https://blocks.druxtjs.org/api/components/DruxtBlock|DruxtBlock}
  * @see {@link ../DruxtBreadcrumb|DruxtBreadcrumb}
  */
 export default {
@@ -26,7 +26,7 @@ export default {
   /**
    * Vue.js Mixins.
    *
-   * @see {@link https://blocks.druxtjs.org/api/mixins/block.html|DruxtBlocksBlockMixin}
+   * @see {@link https://blocks.druxtjs.org/api/mixins/block|DruxtBlocksBlockMixin}
    */
   mixins: [DruxtBlocksBlockMixin],
 }

--- a/packages/menu/src/components/blocks/DruxtBlockSystemMenuBlock.vue
+++ b/packages/menu/src/components/blocks/DruxtBlockSystemMenuBlock.vue
@@ -19,7 +19,7 @@ import { DruxtBlocksBlockMixin } from 'druxt-blocks'
  *   uuid="d4efd803-94af-4742-bc94-ea4360085b74"
  * />
  *
- * @see {@link https://blocks.druxtjs.org/api/components/DruxtBlock.html|DruxtBlock}
+ * @see {@link https://blocks.druxtjs.org/api/components/DruxtBlock|DruxtBlock}
  */
 export default {
   name: 'DruxtBlockSystemMenuBlock',
@@ -27,7 +27,7 @@ export default {
   /**
    * Vue.js Mixins.
    *
-   * @see {@link https://blocks.druxtjs.org/api/mixins/block.html|DruxtBlocksBlockMixin}
+   * @see {@link https://blocks.druxtjs.org/api/mixins/block|DruxtBlocksBlockMixin}
    */
   mixins: [DruxtBlocksBlockMixin],
 

--- a/packages/menu/src/index.js
+++ b/packages/menu/src/index.js
@@ -8,7 +8,7 @@ import { DruxtMenuNuxtModule } from './nuxtModule'
  * @type {class}
  * @exports DruxtMenu
  * @name DruxtMenu
- * @see {@link ./menu.html|DruxtMenu}
+ * @see {@link ./menu|DruxtMenu}
  */
 export { DruxtMenu } from './menu.js'
 
@@ -18,7 +18,7 @@ export { DruxtMenu } from './menu.js'
  * @type {object}
  * @exports DruxtMenuStore
  * @name DruxtMenuStore
- * @see {@link ./stores/menu.html|DruxtMenuStore}
+ * @see {@link ./stores/menu|DruxtMenuStore}
  */
 export { DruxtMenuStore } from './stores/menu.js'
 
@@ -30,7 +30,7 @@ export { DruxtMenuStore } from './stores/menu.js'
  * @type {Function}
  * @exports default
  * @name DruxtMenuNuxtModule
- * @see {@link ./nuxtModule.html|DruxtMenuNuxtModule}
+ * @see {@link ./nuxtModule|DruxtMenuNuxtModule}
  */
 export default DruxtMenuNuxtModule
 

--- a/packages/menu/src/menu.js
+++ b/packages/menu/src/menu.js
@@ -195,5 +195,5 @@ export { DruxtMenu }
  *
  * @typedef {object} ModuleOptions
  *
- * @see {@link ./typedefs/moduleOptions.html|ModuleOptions}
+ * @see {@link ./typedefs/moduleOptions|ModuleOptions}
  */

--- a/packages/menu/src/typedefs/moduleOptions.js
+++ b/packages/menu/src/typedefs/moduleOptions.js
@@ -17,5 +17,5 @@
    * DruxtMenu options.
    *
    * @typedef {object} MenuOptions
-   * @see {@link ./menuOptions.html|MenuOptions}
+   * @see {@link ./menuOptions|MenuOptions}
    */

--- a/packages/router/src/components/index.js
+++ b/packages/router/src/components/index.js
@@ -4,7 +4,7 @@
  * @type {object}
  * @exports DruxtRouterComponent
  * @name DruxtRouterComponent
- * @see {@link ./components/DruxtRouter.html|DruxtRouterComponent}
+ * @see {@link ./components/DruxtRouter|DruxtRouterComponent}
  *
  * @example
  * <script>

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -6,7 +6,7 @@
  * @type {class}
  * @exports DruxtRouter
  * @name DruxtRouter
- * @see {@link ./router.html|DruxtRouter}
+ * @see {@link ./router|DruxtRouter}
  */
 export { DruxtRouter } from './router'
 

--- a/packages/views/src/components/blocks/DruxtBlockViewsBlock.vue
+++ b/packages/views/src/components/blocks/DruxtBlockViewsBlock.vue
@@ -21,7 +21,7 @@ import { DruxtBlocksBlockMixin } from 'druxt-blocks'
  *   uuid="43d613c6-ab66-453d-bce1-e1dfc990b4a1"
  * />
  *
- * @see {@link https://blocks.druxtjs.org/api/components/DruxtBlock.html|DruxtBlock}
+ * @see {@link https://blocks.druxtjs.org/api/components/DruxtBlock|DruxtBlock}
  */
 export default {
   name: 'DruxtBlockViewsBlock',
@@ -29,7 +29,7 @@ export default {
   /**
    * Vue.js Mixins.
    *
-   * @see {@link https://blocks.druxtjs.org/api/mixins/block.html|DruxtBlocksBlockMixin}
+   * @see {@link https://blocks.druxtjs.org/api/mixins/block|DruxtBlocksBlockMixin}
    */
   mixins: [DruxtBlocksBlockMixin],
 

--- a/packages/views/src/mixins/view.js
+++ b/packages/views/src/mixins/view.js
@@ -17,7 +17,7 @@ import { DruxtEntityContextMixin } from 'druxt-entity'
 const DruxtViewsViewMixin = {
   /**
    * Vue.js mixins.
-   * @see {@link https://entity.druxtjs.org/api/mixins/context.html|DruxtEntityContextMixin}
+   * @see {@link https://entity.druxtjs.org/api/mixins/context|DruxtEntityContextMixin}
    * @type {object[]}
    */
   mixins: [DruxtEntityContextMixin],


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Removes all html extensions in the jsdocs to fix some broken links in the API packages documentation.
Resolves #477 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/478"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

