### PR TITLE
chore: update drupal-jsonapi-params to ^2.0.0

### DIFF
--- a/.changeset/wicked-tables-tie.md
+++ b/.changeset/wicked-tables-tie.md
@@ -1,0 +1,12 @@
+---
+"druxt-blocks": patch
+"druxt": patch
+"druxt-entity": patch
+"druxt-menu": patch
+"druxt-schema": patch
+"druxt-site": patch
+"druxt-test-utils": patch
+"druxt-views": patch
+---
+
+updated drupal-jsonapi-params to 2.0.0

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "axios": "^0.21.1",
-    "drupal-jsonapi-params": "^1.1.12",
+    "drupal-jsonapi-params": "^2.0.0",
     "druxt": "^0.18.0",
     "druxt-entity": "^0.24.2",
     "druxt-router": "^0.26.1"

--- a/packages/druxt/package.json
+++ b/packages/druxt/package.json
@@ -42,7 +42,7 @@
     "@nuxtjs/proxy": "^2.1.0",
     "chalk": "^4.1.2",
     "deepmerge": "^4.2.2",
-    "drupal-jsonapi-params": "^1.2.1",
+    "drupal-jsonapi-params": "^2.0.0",
     "md5": "^2.3.0",
     "querystring": "^0.2.0",
     "scule": "^0.2.0"

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "drupal-jsonapi-params": "^1.2.2",
+    "drupal-jsonapi-params": "^2.0.0",
     "druxt": "^0.18.0",
     "druxt-router": "^0.26.1",
     "druxt-schema": "^0.10.2"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "drupal-jsonapi-params": "^1.1.12",
+    "drupal-jsonapi-params": "^2.0.0",
     "druxt": "^0.18.1",
     "druxt-blocks": "^0.15.1"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "consola": "^2.15.0",
-    "drupal-jsonapi-params": "^1.2.2",
+    "drupal-jsonapi-params": "^2.0.0",
     "druxt": "^0.18.0"
   },
   "optionalDependencies": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -42,7 +42,7 @@
     "templates"
   ],
   "dependencies": {
-    "drupal-jsonapi-params": "^1.2.2",
+    "drupal-jsonapi-params": "^2.0.0",
     "druxt": "^0.18.0",
     "druxt-blocks": "^0.15.1",
     "druxt-breadcrumb": "^0.14.1",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -17,7 +17,7 @@
   "main": "dist/druxt-test-utils.ssr.js",
   "module": "dist/druxt-test-utils.esm.js",
   "dependencies": {
-    "drupal-jsonapi-params": "1.2.2",
+    "drupal-jsonapi-params": "2.0.0",
     "jest-mock-axios": "4.5.0"
   },
   "peerDependencies": {

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "deepmerge": "^4.2.2",
-    "drupal-jsonapi-params": "^1.1.12",
+    "drupal-jsonapi-params": "^2.0.0",
     "druxt": "^0.18.0",
     "druxt-blocks": "^0.15.1",
     "druxt-entity": "^0.24.2",


### PR DESCRIPTION
Beep boop! fake renovate bot here!

Updated drupal-json-api params to version 2.0.0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

The version bump to 2.x is due to a bug fix surrounding "shortening" of generated url. It doesn't change the behaviour of response from Drupal, but might break some tests if you have any.

I tried to setup druxt.js in local for running test, however am facing some roadblocks, hence didn't run test to check if there had been any breaking change. 

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/481"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

