### PR TITLE
fix(#497): add proxy settings for deprecated axios

### DIFF
--- a/.changeset/sweet-pumpkins-behave.md
+++ b/.changeset/sweet-pumpkins-behave.md
@@ -1,0 +1,5 @@
+---
+"druxt": patch
+---
+
+Fixed proxy when using deprecated Axios options.

--- a/packages/druxt/src/client.js
+++ b/packages/druxt/src/client.js
@@ -47,7 +47,8 @@ class DruxtClient {
     else {
       this.axios = axios.create({
         ...options.axios || {},
-        baseURL: baseUrl,
+        // Set baseURL if proxy is not enabled.
+        baseURL: baseUrl && !(options.proxy || {}).api ? baseUrl : undefined
       })
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Fix API proxy when using deprecated Axios options method.
- resolves #497 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/498"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

