### PR TITLE
fix(#518): change order of druxt proxies

### DIFF
--- a/.changeset/smart-bags-share.md
+++ b/.changeset/smart-bags-share.md
@@ -1,0 +1,5 @@
+---
+"druxt": patch
+---
+
+Changed order of Druxt Proxy entries.

--- a/packages/druxt/src/nuxt/index.js
+++ b/packages/druxt/src/nuxt/index.js
@@ -77,14 +77,14 @@ const DruxtNuxtModule = async function (moduleOptions = {}) {
     if (this.options.proxy) {
       if (Array.isArray(this.options.proxy)) {
         this.options.proxy = [
-          ...Object.keys(proxies).map((path) => `${options.baseUrl}${path}`),
-          ...this.options.proxy
+          ...this.options.proxy,
+          ...Object.keys(proxies).map((path) => `${options.baseUrl}${path}`)
         ]
       }
       else {
         this.options.proxy = {
-          ...proxies,
-          ...this.options.proxy
+          ...this.options.proxy,
+          ...proxies
         }
       }
     }

--- a/packages/druxt/test/nuxt/index.test.js
+++ b/packages/druxt/test/nuxt/index.test.js
@@ -156,11 +156,11 @@ describe('DruxtJS Nuxt module', () => {
     expect(mock.addModule).toHaveBeenCalledWith('@nuxtjs/proxy')
     // Ensure proxies are set.
     expect(mock.options.proxy).toStrictEqual([
+      `${options.baseUrl}/array-test`,
       `${options.baseUrl}${options.endpoint}`,
       `${options.baseUrl}/en${options.endpoint}`,
       `${options.baseUrl}/es${options.endpoint}`,
       `${options.baseUrl}/router/translate-path`,
-      `${options.baseUrl}/array-test`,
     ])
 
     // Set object proxy settings.
@@ -172,10 +172,10 @@ describe('DruxtJS Nuxt module', () => {
     expect(mock.addModule).toHaveBeenCalledWith('@nuxtjs/proxy')
     // Ensure proxies are set.
     expect(mock.options.proxy).toStrictEqual({
+      '/object-test': options.baseUrl,
       [`/en${options.endpoint}`]: options.baseUrl,
       [`/es${options.endpoint}`]: options.baseUrl,
       [options.endpoint]: options.baseUrl,
-      '/object-test': options.baseUrl,
       '/router/translate-path': options.baseUrl
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Changed the order of Druxt Proxy entries, allowing users to override proxy entries.
- Fixed #518 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/519"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

