### PR TITLE
fix(#538): fix breadcrumb multilingual home bug

### DIFF
--- a/.changeset/real-weeks-pull.md
+++ b/.changeset/real-weeks-pull.md
@@ -1,0 +1,5 @@
+---
+"druxt-breadcrumb": minor
+---
+
+fix(#538): Fixed issue with multiple Home crumbs on multilingual sites.

--- a/packages/breadcrumb/src/components/DruxtBreadcrumb.vue
+++ b/packages/breadcrumb/src/components/DruxtBreadcrumb.vue
@@ -143,12 +143,13 @@ export default {
           route = false
         }
 
-        if (route.label) {
+        // If this route has a label and doesn't resolve to the current path, add to the crumbs.
+        if (route.label && route.resolvedPath !== path) {
           crumbs.push({ to, text: route.label })
         }
 
         // If this route is the home path, prevent a duplicate home item.
-        if (route.isHomePath) {
+        if (route.isHomePath || to === ['/', (route.props || {}).langcode].filter((o) => o).join('')) {
           addHome = false
         }
 

--- a/packages/breadcrumb/test/components/DruxtBreadcrumb.test.js
+++ b/packages/breadcrumb/test/components/DruxtBreadcrumb.test.js
@@ -37,7 +37,11 @@ const mountComponent = ({ path, routes, propsData, options }) => {
       path,
       route: {
         label,
-        isHomePath
+        isHomePath,
+        props: {
+          langcode: undefined
+        },
+        resolvedPath: path
       }
     })
   }
@@ -69,7 +73,11 @@ describe('DruxtBreadcrumb', () => {
 
     expect(wrapper.vm.route).toStrictEqual({
       isHomePath: true,
-      label: '/'
+      label: '/',
+      props: {
+        langcode: undefined
+      },
+      resolvedPath: '/'
     })
     expect(Object.keys(wrapper.vm.routes)).toHaveLength(1)
 
@@ -90,7 +98,11 @@ describe('DruxtBreadcrumb', () => {
 
     expect(wrapper.vm.route).toStrictEqual({
       isHomePath: false,
-      label: '/level-1'
+      label: '/level-1',
+      props: {
+        langcode: undefined
+      },
+      resolvedPath: '/level-1'
     })
 
     expect(wrapper.vm.crumbs).toHaveLength(2)
@@ -108,7 +120,11 @@ describe('DruxtBreadcrumb', () => {
 
     expect(wrapper.vm.route).toStrictEqual({
       isHomePath: false,
-      label: '/level-1/level-2'
+      label: '/level-1/level-2',
+      props: {
+        langcode: undefined
+      },
+      resolvedPath: '/level-1/level-2'
     })
 
     expect(wrapper.vm.crumbs).toHaveLength(3)
@@ -141,7 +157,11 @@ describe('DruxtBreadcrumb', () => {
 
     expect(wrapper.vm.route).toStrictEqual({
       isHomePath: false,
-      label: '/level-1/level-2'
+      label: '/level-1/level-2',
+      props: {
+        langcode: undefined
+      },
+      resolvedPath: '/level-1/level-2',
     })
 
     expect(wrapper.vm.crumbs).toHaveLength(2)
@@ -184,7 +204,11 @@ describe('DruxtBreadcrumb', () => {
 
     expect(wrapper.vm.route).toStrictEqual({
       isHomePath: false,
-      label: '/error/level-2'
+      label: '/error/level-2',
+      props: {
+        langcode: undefined
+      },
+      resolvedPath: '/error/level-2',
     })
 
     expect(wrapper.vm.crumbs).toHaveLength(2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Fixed DruxtBreadcrumb component to prevent duplicate Home crumbs being created.
- Resolved #538


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/549"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

