### PR TITLE
feat(#539): default to JSON:API Menu Items data

### DIFF
--- a/.changeset/bright-sloths-cheat.md
+++ b/.changeset/bright-sloths-cheat.md
@@ -1,0 +1,5 @@
+---
+"druxt-menu": minor
+---
+
+feat(#539): Use JSON:API Menu Items data by default.

--- a/packages/menu/src/nuxtModule.js
+++ b/packages/menu/src/nuxtModule.js
@@ -31,6 +31,7 @@ const DruxtMenuNuxtModule = async function (moduleOptions = {}) {
     baseUrl: moduleOptions.baseUrl,
     ...(this.options || {}).druxt || {},
     menu: {
+      jsonApiMenuItems: true,
       ...((this.options || {}).druxt || {}).menu,
       ...moduleOptions,
     }

--- a/packages/menu/test/nuxtModule.test.js
+++ b/packages/menu/test/nuxtModule.test.js
@@ -20,6 +20,24 @@ const mock = {
 }
 
 test('Nuxt module', async () => {
+  // Use module with defaults.
   await DruxtMenuNuxtModule.call(mock)
   expect(mock.addPlugin).toHaveBeenCalled()
+
+  // Expect JSON:API Menu Items tp be enabled.
+  expect(mock.addModule).toHaveBeenLastCalledWith(['druxt', {
+    baseUrl: undefined,
+    menu: {
+      jsonApiMenuItems: true
+    }
+  }])
+
+  // Use overridden options; Drupal content menu items.
+  await DruxtMenuNuxtModule.call({ ...mock, options: { druxt: { menu: { jsonApiMenuItems: false }}} })
+  expect(mock.addModule).toHaveBeenLastCalledWith(['druxt', {
+    baseUrl: undefined,
+    menu: {
+      jsonApiMenuItems: false
+    }
+  }])
 })

--- a/packages/site/src/nuxtModule.js
+++ b/packages/site/src/nuxtModule.js
@@ -17,10 +17,6 @@ const DruxtSiteNuxtModule = async function (moduleOptions = {}) {
   const options = {
     baseUrl: moduleOptions.baseUrl,
     ...(this.options || {}).druxt || {},
-    menu: {
-      jsonApiMenuItems: true,
-      ...((this.options || {}).druxt || {}).menu,
-    },
     proxy: {
       api: false,
       files: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Updated DruxtMenu to use JSON:API Menu Items module data by default.
- Resolved #539

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/550"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

