### PR TITLE
fix(#552): sanitise empty emitted strings

### DIFF
--- a/.changeset/cuddly-ears-breathe.md
+++ b/.changeset/cuddly-ears-breathe.md
@@ -1,0 +1,5 @@
+---
+"druxt-entity": patch
+---
+
+fix(#552): sanitised empty emitted strings to prevent `true` error on themed text fields.

--- a/examples/druxt-site/components/druxt/field/undefined/Form.vue
+++ b/examples/druxt-site/components/druxt/field/undefined/Form.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <label><strong>{{ $parent.label.text }}:</strong><br /></label>
+    <input
+      v-model="model"
+      size="60"
+      type="text"
+    ></input>
+  </div>
+</template>
+
+<script>
+import { DruxtFieldMixin } from 'druxt-entity'
+export default {
+  mixins: [DruxtFieldMixin],
+}
+</script>

--- a/examples/druxt-site/pages/_langcode/contact.vue
+++ b/examples/druxt-site/pages/_langcode/contact.vue
@@ -1,0 +1,3 @@
+<template>
+  <DruxtEntityForm type="contact_message--feedback" />
+</template>

--- a/packages/entity/src/components/DruxtEntity.vue
+++ b/packages/entity/src/components/DruxtEntity.vue
@@ -395,7 +395,12 @@ export default {
           on: {
             input: (value) => {
               const type = !field.relationship ? 'attributes' : 'relationships'
-              this.model[type][id] = value
+              if (value) {
+                this.model[type][id] = value
+              }
+              else if (this.model[type][id]) {
+                delete this.model[type][id]
+              }
               this.$emit('input', this.model)
             }
           },

--- a/packages/entity/src/components/DruxtField.vue
+++ b/packages/entity/src/components/DruxtField.vue
@@ -1,6 +1,10 @@
 <script>
 import DruxtModule from 'druxt/dist/components/DruxtModule.vue'
 
+// Extract the DruxtModule model watch.
+const modelWatch = DruxtModule.watch.model
+delete DruxtModule.watch.model
+
 /**
  * Renders a Drupal Field using Drupals by field type and formatter settings.
  *
@@ -164,6 +168,14 @@ export default {
     errors() {
       this.component.props.errors = this.errors
       this.component.propsData.errors = this.errors
+    },
+
+    model() {
+      // Sanitize empty string based fields.
+      if (this.model === '') { this.model = undefined }
+
+      // Invoke the DruxtModule model watch callback.
+      modelWatch.call(this)
     },
   },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Sanitised empty emitted string in hijacked model watch in the DruxtField component to prevent value being replaced with `true`
- Remove empty emitted attributes and relationships from DruxtEntity model
- Resolves #552

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<a href="https://gitpod.io/#https://github.com/druxt/druxt.js/pull/556"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

