### PR TITLE
fix(#628): add prefix to included resources fetch

### DIFF
--- a/packages/druxt/src/stores/druxt.js
+++ b/packages/druxt/src/stores/druxt.js
@@ -239,8 +239,9 @@ const DruxtStore = ({ store }) => {
 
                 return data.filter((o) => typeof o === 'object' && o).map((o) => {
                   return dispatch('getResource', {
-                    type: o.type,
                     id: o.id,
+                    prefix,
+                    type: o.type,
                     query: { ...queryObject, include },
                   })
                 })


### PR DESCRIPTION
Re-fetching resources from the `include` section in the `queryObject`

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Resolves #628 


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why) → _Parameters were not tested before, so the `getResource - includes` test still passes_
- [ ] All new and existing tests are passing.

