### PR TITLE
fix(#679): add nuxt auth axios instance to plugin

### DIFF
--- a/.changeset/wise-months-double.md
+++ b/.changeset/wise-months-double.md
@@ -1,0 +1,5 @@
+---
+"druxt-menu": patch
+---
+
+feat(#679): Adds Nuxt Auth Axios instance to the DruxtMenu plugin to ensure correct results are provided when authenticated.

--- a/packages/menu/templates/plugin.js
+++ b/packages/menu/templates/plugin.js
@@ -1,6 +1,6 @@
 import { DruxtMenu } from 'druxt-menu'
 
-export default (context, inject) => {
+export default ({ app }, inject) => {
   const baseUrl = '<%= options.baseUrl %>'
   const options = {}
 
@@ -10,6 +10,14 @@ export default (context, inject) => {
 
   <% if (options.menu) { %>
   options.menu = <%= JSON.stringify(options.menu) %>
+  <% } %>
+
+  <% if (typeof options.axios === 'object') { %>
+  // Axios settings.
+  options.axios = <%= JSON.stringify(options.axios) %>
+  <% } else { %>
+  // Use the @nuxtjs/axios module Axios instance.
+  options.axios = app.$axios
   <% } %>
 
   const druxtMenu = new DruxtMenu(baseUrl, options)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Adds Nuxt Auth Axios instance to the DruxtMenu plugin to ensure correct results are provided when authenticated.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Refactor:
- Replaced the `context` parameter with `{ app }` in the exported function for improved code readability and maintainability.
- Updated the handling of the `options.axios` property. If it's an object, it is now directly assigned to `options.axios`. Otherwise, the `app.$axios` instance is used. This change simplifies the code and improves its efficiency.

New Feature:
- Added a patch to the "druxt-menu" package that includes a new feature. The feature adds the Nuxt Auth Axios instance to the DruxtMenu plugin, ensuring correct results are provided when authenticated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->