### PR TITLE
feat(#684): add druxtMenu/flushEntities mutation

### DIFF
--- a/.changeset/happy-ties-rule.md
+++ b/.changeset/happy-ties-rule.md
@@ -1,0 +1,5 @@
+---
+"druxt-menu": minor
+---
+
+feat(#684): added druxtMenu/flushEntities Vuex mutation.

--- a/packages/menu/src/components/DruxtMenu.vue
+++ b/packages/menu/src/components/DruxtMenu.vue
@@ -222,6 +222,7 @@ export default {
   mounted() {
     // If logged in and statically generated, re-fetch the menu.
     if (this?.$auth?.loggedIn && this?.$store?.app?.context?.isStatic) {
+      this.$store.commit('druxtMenu/flushEntities', { prefix: this.lang })
       const settings = this.$options.druxt.settings(this, this.component.settings)
       this.$options.druxt.fetchData.call(this, settings)
     }

--- a/packages/menu/src/stores/menu.js
+++ b/packages/menu/src/stores/menu.js
@@ -49,7 +49,21 @@ const DruxtMenuStore = ({ store }) => {
           const entity = entities[index]
           Vue.set(state.entities[prefix], entity.id, entity)
         }
-      }
+      },
+
+      /**
+       * @name flushEntities
+       * @mutator {object} flushEntities=entities Removes JSON:API menu item entities from the Vuex state object.
+       * @param {flushEntitiesContext} context
+       *
+       * @example @lang js
+       * // Flush all menu entities.
+       * this.$store.commit('druxt/flushCollection', {})
+       */
+      flushEntities (state, { prefix }) {
+        if (!prefix) Vue.set(state, 'entities', {})
+        else Vue.set(state.entities, prefix, {})
+      },
     },
 
     /**
@@ -119,4 +133,17 @@ export { DruxtMenuStore }
  *
  * @typedef {object} State
  * @property {object} entities - The Drupal JSON:API Menu Item entities.
+ */
+
+/**
+ * Parameters for the `flushEntities` mutation.
+ *
+ * @typedef {object} flushEntitiesContext
+ *
+ * @param {string} [prefix] - (Optional) The JSON:API endpoint prefix or langcode.
+ *
+ * @example @lang js
+ * {
+ *   prefix: 'en'
+ * }
  */

--- a/packages/menu/src/stores/menu.js
+++ b/packages/menu/src/stores/menu.js
@@ -61,8 +61,8 @@ const DruxtMenuStore = ({ store }) => {
        * this.$store.commit('druxt/flushCollection', {})
        */
       flushEntities (state, { prefix }) {
-        if (!prefix) Vue.set(state, 'entities', {})
-        else Vue.set(state.entities, prefix, {})
+        if (!prefix || typeof state.entities !== 'object') Vue.set(state, 'entities', {})
+        if (prefix) Vue.set(state.entities, prefix, {})
       },
     },
 

--- a/packages/menu/test/stores/menu.test.js
+++ b/packages/menu/test/stores/menu.test.js
@@ -44,9 +44,11 @@ describe('DruxtStore', () => {
   test('flushEntities', async () => {
     expect(store.state.druxtMenu.entities).toStrictEqual({})
     store.commit('druxtMenu/addEntities', { entities: [{ id: 'test' }] })
+    store.commit('druxtMenu/addEntities', { entities: [{ id: 'test2' }], prefix: 'es' })
     expect(Object.entries(store.state.druxtMenu.entities[undefined]).length).toBe(1)
     store.commit('druxtMenu/flushEntities', { prefix: 'undefined' })
     expect(Object.entries(store.state.druxtMenu.entities[undefined]).length).toBe(0)
     store.commit('druxtMenu/flushEntities', {})
+    expect(Object.entries(store.state.druxtMenu.entities).length).toBe(0)
   })
 })

--- a/packages/menu/test/stores/menu.test.js
+++ b/packages/menu/test/stores/menu.test.js
@@ -33,4 +33,20 @@ describe('DruxtStore', () => {
     expect(store.$druxtMenu.get).toHaveBeenCalledWith('main', { test: true }, undefined)
     store.dispatch('druxtMenu/get', 'name')
   })
+
+  test('AddEntities', async () => {
+    expect(store.state.druxtMenu.entities).toStrictEqual({})
+    store.commit('druxtMenu/addEntities', { entities: [{ id: 'test' }] })
+    expect(Object.entries(store.state.druxtMenu.entities[undefined]).length).toBe(1)
+    expect(store.state.druxtMenu.entities[undefined].test).toStrictEqual({ id: 'test' })
+  })
+
+  test('flushEntities', async () => {
+    expect(store.state.druxtMenu.entities).toStrictEqual({})
+    store.commit('druxtMenu/addEntities', { entities: [{ id: 'test' }] })
+    expect(Object.entries(store.state.druxtMenu.entities[undefined]).length).toBe(1)
+    store.commit('druxtMenu/flushEntities', { prefix: 'undefined' })
+    expect(Object.entries(store.state.druxtMenu.entities[undefined]).length).toBe(0)
+    store.commit('druxtMenu/flushEntities', {})
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Adds druxtMenu/flushEntities Vuex mutation to allow the menu vuex store to be flushed when logging in/out with an authenticated user.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented a feature to refresh menu data for logged-in users, ensuring up-to-date information is displayed.

- **Refactor**
  - Enhanced the menu data management to allow selective clearing of menu-related data from the application state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->