### PR TITLE
chore(#517): remove deprecated fields by default

### DIFF
--- a/.changeset/strange-bottles-impress.md
+++ b/.changeset/strange-bottles-impress.md
@@ -1,0 +1,5 @@
+---
+"druxt-entity": minor
+---
+
+chore(#517): removed deprecated entity component fields by default

--- a/packages/entity/README.md
+++ b/packages/entity/README.md
@@ -28,9 +28,6 @@ module.exports = {
   druxt: {
     baseUrl: 'https://demo-api.druxtjs.org',
     entity: {
-      component: {
-        fields: false,
-      },
       query: {
         schema: true,
         fields: ['path', 'title'],
@@ -97,7 +94,7 @@ These options are specific to this module.
 
 | Option | Type | Required | Default | Description |
 | --- | --- | --- | --- | --- |
-| `entity.components.fields` | `boolean` | No | `true` | Whether to import deprecated default Field components. |
+| `entity.components.fields` | `boolean` | No | `false` | Whether to import deprecated default Field components. |
 | `entity.query.fields` | `string[]` | No | `[]` | An array of fields to filter all Entity JSON:API queries. |
 | `entity.query.schema` | `boolean` | No | `false` | Whether to automatically filter fields based on Display schema. |
 

--- a/packages/entity/src/nuxtModule.js
+++ b/packages/entity/src/nuxtModule.js
@@ -38,7 +38,7 @@ const DruxtEntityNuxtModule = async function (moduleOptions = {}) {
       ...((this.options || {}).druxt || {}).entity,
       ...moduleOptions,
       components: {
-        fields: true,
+        fields: false,
         ...(((this.options || {}).druxt || {}).entity || {}).components,
         ...moduleOptions.components
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- Changes the default behaviour for including deprecated entity fields.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the Druxt module configuration for improved performance and customization. Default settings for entity components fields are now set to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->