### PR TITLE
fix(druxt): re-hydrate included resources on getCollection cache hit

### DIFF
--- a/.changeset/lucky-moons-wave.md
+++ b/.changeset/lucky-moons-wave.md
@@ -1,0 +1,5 @@
+---
+'druxt': patch
+---
+
+fix(#781): re-hydrate included resources on getCollection cache hit

--- a/packages/druxt/src/stores/druxt.js
+++ b/packages/druxt/src/stores/druxt.js
@@ -85,10 +85,10 @@ const DruxtStore = ({ store }) => {
         // Store and dehydrate collection resources.
         collection.data = dehydrateResources({ commit: this.commit, prefix, queryObject, resources: collection.data })
 
-        // Extract and store included resources.
+        // Keep the dehydrated refs (don't delete) so a cache hit in
+        // getCollection can re-hydrate `included`, same as `data`.
         if (collection.included) {
           collection.included = dehydrateResources({ commit: this.commit, prefix, queryObject, resources: collection.included })
-          delete collection.included
         }
 
         // Recursively merge new collection data into stored collection.
@@ -207,10 +207,13 @@ const DruxtStore = ({ store }) => {
 
         // If collection hash exists, re-hydrate and return the data.
         if (!bypassCache && ((state.collections[type] || {})[hash] || {})[prefix]) {
+          const cached = state.collections[type][hash][prefix]
           return {
-            ...state.collections[type][hash][prefix],
+            ...cached,
             // Hydrate resource data.
-            data: state.collections[type][hash][prefix].data.map((o) => ((state.resources[o.type][o.id] || {})[prefix] || {}).data)
+            data: cached.data.map((o) => ((state.resources[o.type][o.id] || {})[prefix] || {}).data),
+            // Same for included - a cache hit must match a fresh fetch.
+            ...(cached.included ? { included: cached.included.map((o) => ((state.resources[o.type][o.id] || {})[prefix] || {}).data) } : {}),
           }
         }
 

--- a/packages/druxt/test/stores/druxt.test.js
+++ b/packages/druxt/test/stores/druxt.test.js
@@ -62,8 +62,12 @@ describe('DruxtStore', () => {
       expect.objectContaining({ id, type: 'node--page' })
     )
 
-    // Expect the collection be stored without included data.
-    expect(store.state.druxt.collections['node--page']._default[undefined].included).toBeFalsy()
+    // Expect the collection be stored with dehydrated (not dropped)
+    // included resources, so a later cache hit can re-hydrate `included`
+    // the same way it re-hydrates `data`.
+    expect(store.state.druxt.collections['node--page']._default[undefined].included[0]).toStrictEqual(
+      expect.objectContaining({ id: included[0].id, type: 'node--article' })
+    )
   })
 
   test('addResource', async () => {
@@ -297,6 +301,26 @@ describe('DruxtStore', () => {
 
     await store.dispatch('druxt/getCollection', { type: 'node--page', query: {} })
     expect(mockAxios.get).toHaveBeenCalledTimes(2)
+  })
+
+  test('getCollection cache hit re-hydrates included data', async () => {
+    const mockCollectionPage = await getMockCollection('node--page')
+    const includedId = 'included-article-uuid'
+    store.commit('druxt/addCollection', {
+      collection: {
+        ...mockCollectionPage,
+        included: [{ type: 'node--article', id: includedId, attributes: {} }],
+      },
+      type: 'node--page',
+      hash: '_default',
+    })
+
+    // A cache hit must return `included` the same way a fresh fetch would.
+    const cached = await store.dispatch('druxt/getCollection', { type: 'node--page' })
+    expect(cached.included).toHaveLength(1)
+    expect(cached.included[0]).toStrictEqual(
+      expect.objectContaining({ id: includedId, type: 'node--article' })
+    )
   })
 
   test('flushCollection', async () => {


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

`addCollection` dehydrated `included` resources into `state.resources` but then deleted them from the stored collection. So a second `getCollection` dispatch for an already-cached query returned `included: undefined`, and anything resolving an included resource, such as an image or media reference, silently got nothing back on the cache hit.

This keeps the dehydrated `included` refs on the stored collection and reconstructs them on a cache hit, the same way `data` already is. Includes a changeset.

Resolves: #781

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

## Screenshots/Media

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached collections so related resources are preserved and restored correctly.
  * Ensured cached results remain consistent with fresh fetches, including associated resource data.
  * Removed stale related-resource references when later collection responses omit them.
  * Improved cached collection retrieval after related resources are cleared.

* **Tests**
  * Added coverage for cache hits, resource flushing, and changes to included-resource data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->