### PR TITLE
ci(lint): add a blocking Vale prose lint for AI-tell patterns in docs

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -25,6 +25,7 @@ drush
 Drupals
 druxt
 druxtjs
+endswith
 esm
 felixfbecker
 frontpage
@@ -40,10 +41,12 @@ Ksection
 langcode
 longname
 mailhog
+makedirs
 markdownlint
 metatag
 metatags
 mise
+namelist
 npmjs
 nuxt
 nuxtjs
@@ -56,6 +59,7 @@ scule
 siroc
 ssr
 Standardised
+startswith
 storybook
 stubber
 Themable
@@ -72,3 +76,4 @@ yaml
 yamllint
 yarnpkg
 yarnrc
+zipfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,23 @@ jobs:
           curl -sL "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
           echo "${vale_sha256}  /tmp/vale.tar.gz" | sha256sum -c -
           tar -xzf /tmp/vale.tar.gz -C /tmp vale
+
+          ai_tells_version="1.31.0"
+          ai_tells_sha256="bc1267248f13e65928475c439ad7ae1bf806a20d09254c08d7d8c4a9c8b811f0"
+          curl -sL "https://github.com/tbhb/vale-ai-tells/releases/download/v${ai_tells_version}/ai-tells.zip" -o /tmp/ai-tells.zip
+          echo "${ai_tells_sha256}  /tmp/ai-tells.zip" | sha256sum -c -
+          python3 -c "
+          import zipfile, os
+          with zipfile.ZipFile('/tmp/ai-tells.zip') as z:
+              for name in z.namelist():
+                  if name.startswith('ai-tells/styles/') and not name.endswith('/'):
+                      target = os.path.join('docs/nuxt/styles', name[len('ai-tells/styles/'):])
+                      os.makedirs(os.path.dirname(target), exist_ok=True)
+                      with open(target, 'wb') as f:
+                          f.write(z.read(name))
+          "
+
           cd docs/nuxt
-          /tmp/vale sync
           /tmp/vale content
 
       - name: Renovate config validator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,28 @@ jobs:
       - name: CSpell
         run: yarn lint:cspell
 
+      - name: Vale (AI-tell prose lint)
+        run: |
+          vale_version="3.17.1"
+          arch="$(uname -m)"
+          case "$arch" in
+            aarch64|arm64)
+              vale_arch=arm64
+              vale_sha256=92d91ebf9ee69ec077379be95cd09e6710ab33d3d5bab66bb482e66ebc80dc23
+              ;;
+            x86_64)
+              vale_arch=64-bit
+              vale_sha256=db947f89f2292e6a0381a61de155f6a5f5cb4cb460ca178ea412ef605559cefd
+              ;;
+            *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+          esac
+          curl -sL "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
+          echo "${vale_sha256}  /tmp/vale.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/vale.tar.gz -C /tmp vale
+          cd docs/nuxt
+          /tmp/vale sync
+          /tmp/vale content
+
       - name: Renovate config validator
         run: yarn lint:renovate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,13 +103,13 @@ jobs:
               ;;
             *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
           esac
-          curl -sL "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
+          curl -sL --max-time 60 "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
           echo "${vale_sha256}  /tmp/vale.tar.gz" | sha256sum -c -
           tar -xzf /tmp/vale.tar.gz -C /tmp vale
 
           ai_tells_version="1.31.0"
           ai_tells_sha256="bc1267248f13e65928475c439ad7ae1bf806a20d09254c08d7d8c4a9c8b811f0"
-          curl -sL "https://github.com/tbhb/vale-ai-tells/releases/download/v${ai_tells_version}/ai-tells.zip" -o /tmp/ai-tells.zip
+          curl -sL --max-time 60 "https://github.com/tbhb/vale-ai-tells/releases/download/v${ai_tells_version}/ai-tells.zip" -o /tmp/ai-tells.zip
           echo "${ai_tells_sha256}  /tmp/ai-tells.zip" | sha256sum -c -
           python3 -c "
           import zipfile, os

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,9 +173,25 @@ lint:vale:
       tar -xzf /tmp/vale.tar.gz -C /usr/local/bin vale
       chmod +x /usr/local/bin/vale
     - section_end "vale-install"
+    - section_start "vale-style" "Installing the ai-tells style package"
+    - |
+      ai_tells_version="1.31.0"
+      ai_tells_sha256="bc1267248f13e65928475c439ad7ae1bf806a20d09254c08d7d8c4a9c8b811f0"
+      curl -sL "https://github.com/tbhb/vale-ai-tells/releases/download/v${ai_tells_version}/ai-tells.zip" -o /tmp/ai-tells.zip
+      echo "${ai_tells_sha256}  /tmp/ai-tells.zip" | sha256sum -c - || { echo "ai-tells checksum mismatch" >&2; exit 1; }
+      python3 -c "
+      import zipfile, os
+      with zipfile.ZipFile('/tmp/ai-tells.zip') as z:
+          for name in z.namelist():
+              if name.startswith('ai-tells/styles/') and not name.endswith('/'):
+                  target = os.path.join('docs/nuxt/styles', name[len('ai-tells/styles/'):])
+                  os.makedirs(os.path.dirname(target), exist_ok=True)
+                  with open(target, 'wb') as f:
+                      f.write(z.read(name))
+      "
+    - section_end "vale-style"
     - section_start "vale-lint" "Linting docs/nuxt/content for AI-tell prose patterns"
     - cd docs/nuxt
-    - vale sync
     - vale content
     - section_end "vale-lint"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,7 @@ lint:vale:
           ;;
         *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
       esac
-      curl -sL "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
+      curl -sL --max-time 60 "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
       echo "${vale_sha256}  /tmp/vale.tar.gz" | sha256sum -c - || { echo "vale checksum mismatch" >&2; exit 1; }
       tar -xzf /tmp/vale.tar.gz -C /usr/local/bin vale
       chmod +x /usr/local/bin/vale
@@ -177,7 +177,7 @@ lint:vale:
     - |
       ai_tells_version="1.31.0"
       ai_tells_sha256="bc1267248f13e65928475c439ad7ae1bf806a20d09254c08d7d8c4a9c8b811f0"
-      curl -sL "https://github.com/tbhb/vale-ai-tells/releases/download/v${ai_tells_version}/ai-tells.zip" -o /tmp/ai-tells.zip
+      curl -sL --max-time 60 "https://github.com/tbhb/vale-ai-tells/releases/download/v${ai_tells_version}/ai-tells.zip" -o /tmp/ai-tells.zip
       echo "${ai_tells_sha256}  /tmp/ai-tells.zip" | sha256sum -c - || { echo "ai-tells checksum mismatch" >&2; exit 1; }
       python3 -c "
       import zipfile, os

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,6 +141,44 @@ lint:cspell:
     - yarn lint:cspell
     - section_end "cspell"
 
+# Prose-quality lint for docs/nuxt/content: flags AI-generated-text tells
+# (em-dash overuse, hedging, anthropomorphic verbs, overused vocabulary, etc.)
+# via the vale-ai-tells style package, scoped by docs/nuxt/.vale.ini to
+# hand-authored content only (content/api and content/modules/*/readme are
+# generated - see the exclusions in that file). Blocking: all real findings
+# against current docs content are fixed, and ai-tells.ColonUsage is disabled
+# site-wide (see the comment in .vale.ini) since it can't tell this site's
+# "**term**: Description" convention apart from a genuine AI tell.
+lint:vale:
+  stage: lint
+  interruptible: true
+  script:
+    - section_start "vale-install" "Installing Vale"
+    - |
+      vale_version="3.17.1"
+      arch="$(uname -m)"
+      case "$arch" in
+        aarch64|arm64)
+          vale_arch=arm64
+          vale_sha256=92d91ebf9ee69ec077379be95cd09e6710ab33d3d5bab66bb482e66ebc80dc23
+          ;;
+        x86_64)
+          vale_arch=64-bit
+          vale_sha256=db947f89f2292e6a0381a61de155f6a5f5cb4cb460ca178ea412ef605559cefd
+          ;;
+        *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+      esac
+      curl -sL "https://github.com/vale-cli/vale/releases/download/v${vale_version}/vale_${vale_version}_Linux_${vale_arch}.tar.gz" -o /tmp/vale.tar.gz
+      echo "${vale_sha256}  /tmp/vale.tar.gz" | sha256sum -c - || { echo "vale checksum mismatch" >&2; exit 1; }
+      tar -xzf /tmp/vale.tar.gz -C /usr/local/bin vale
+      chmod +x /usr/local/bin/vale
+    - section_end "vale-install"
+    - section_start "vale-lint" "Linting docs/nuxt/content for AI-tell prose patterns"
+    - cd docs/nuxt
+    - vale sync
+    - vale content
+    - section_end "vale-lint"
+
 lint:js:
   extends: .node
   stage: lint

--- a/docs/nuxt/.gitignore
+++ b/docs/nuxt/.gitignore
@@ -101,3 +101,6 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# Vale style packages (downloaded by `vale sync`, not committed)
+styles/

--- a/docs/nuxt/.vale.ini
+++ b/docs/nuxt/.vale.ini
@@ -1,6 +1,14 @@
 StylesPath = styles
 MinAlertLevel = suggestion
 
+# For local dev: `vale sync` reads this to fetch the style package (fine for
+# a local run - same trust model as `npm install` without a lockfile hash).
+# CI does NOT rely on this: it downloads the same release asset separately,
+# verifies its SHA-256, and extracts it into StylesPath itself, since `vale
+# sync` doesn't check the archive's contents against anything. If you bump
+# this version, update the pinned URL and checksum in both CI files too
+# (.gitlab-ci.yml and .github/workflows/ci.yml) - all three need to move
+# together.
 Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.31.0/ai-tells.zip
 
 # Scoped to hand-authored prose only - the same generated-content exclusion

--- a/docs/nuxt/.vale.ini
+++ b/docs/nuxt/.vale.ini
@@ -1,0 +1,30 @@
+StylesPath = styles
+MinAlertLevel = suggestion
+
+Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.31.0/ai-tells.zip
+
+# Scoped to hand-authored prose only - the same generated-content exclusion
+# already used by markdownlint-cli2 and cspell (see .markdownlint-cli2.jsonc,
+# .cspell.json): content/api/ is scraped verbatim from JSDoc, and
+# content/modules/*/readme/ mirrors package READMEs. Neither is prose someone
+# wrote for this site.
+[content/**/*.md]
+BasedOnStyles = ai-tells
+
+# ai-tells.ColonUsage flags any capitalized word after a colon (its own docs
+# call this a "known limitation": a run-in bold label like "**Note:** Like
+# this." flags too, since Vale strips markdown before matching, and says to
+# disable the rule where that convention is established). This site leans on
+# that exact convention everywhere: "**term**: Description" parameter lists
+# in every module README, "_Example: ..._" captions, "TODO:" markers, and
+# proper nouns like "Druxt" after a colon ("TL;DR: Druxt = DRUpal + nUXT").
+# A per-word exception list would have to cover most of the English words
+# that can start a sentence, so disabling is the rule author's own advice,
+# not a workaround.
+ai-tells.ColonUsage = NO
+
+[content/api/**/*.md]
+BasedOnStyles =
+
+[content/modules/*/readme/**/*.md]
+BasedOnStyles =

--- a/docs/nuxt/content/guide/README.md
+++ b/docs/nuxt/content/guide/README.md
@@ -9,7 +9,7 @@ weight: -10
 
 ### What is Druxt?
 
-Druxt is a framework for building Fully Decoupled Drupal and Nuxt.js applications and sites. It allows you to leverage the content modelling and management power of Drupal, and build elegant user experiences with Nuxt.js.
+Druxt is a framework for building Fully Decoupled Drupal and Nuxt.js applications and sites. It allows you to use the content modelling and management power of Drupal, and build elegant user experiences with Nuxt.js.
 
 > TL;DR: Druxt = DRUpal + nUXT.
 

--- a/docs/nuxt/content/guide/deprecations.md
+++ b/docs/nuxt/content/guide/deprecations.md
@@ -13,7 +13,7 @@ TODO: Move to API documentation
 
 **Version:** `>= 0.6.0`
 
-Prior to `0.6.0`, the DruxtStore store used a `hash` argument to separate the filtered resource results:
+Prior to `0.6.0`, DruxtStore used a `hash` argument to separate the filtered resource results:
 
 ```js
 // Deprecated, hash is no longer required.

--- a/docs/nuxt/content/guide/deprecations.md
+++ b/docs/nuxt/content/guide/deprecations.md
@@ -13,7 +13,7 @@ TODO: Move to API documentation
 
 **Version:** `>= 0.6.0`
 
-Prior to `0.6.0`, the DruxtStore store used a `hash` argument to separate the various filtered resource results:
+Prior to `0.6.0`, the DruxtStore store used a `hash` argument to separate the filtered resource results:
 
 ```js
 // Deprecated, hash is no longer required.

--- a/docs/nuxt/content/guide/devtools.md
+++ b/docs/nuxt/content/guide/devtools.md
@@ -11,15 +11,15 @@ weight: -3
 
 Druxt integrates with the Vue.js Devtools to provide easier access to debug information, and to simplify the theming process.
 
-* * *
+---
 
 ## Features
 
-* DruxtJS custom inspector with connection information.
-* Druxt theme component template creation tool.
-* Druxt tag in the component inspector.
+- DruxtJS custom inspector with connection information.
+- Druxt tool for creating theme component templates.
+- Druxt tag in the component inspector.
 
-* * *
+---
 
 ### Installation
 

--- a/docs/nuxt/content/guide/getting-started.md
+++ b/docs/nuxt/content/guide/getting-started.md
@@ -15,7 +15,7 @@ Druxt gives you the tools to connect your Nuxt.js frontend to your Drupal JSON:A
 
 All Druxt sites and applications need both Drupal (backend) and Nuxt (frontend) to be installed.
 
-Each codebase can live in its own directory within a single repository, or exist in separate repositories.
+Each codebase can live in its own directory within one repository, or exist in separate repositories.
 
 ---
 
@@ -63,7 +63,7 @@ Each codebase can live in its own directory within a single repository, or exist
    };
    ```
 
-   \* _**Note:** Replace `https://demo-api.druxtjs.org` with your own Drupal backend._
+   \* _Replace `https://demo-api.druxtjs.org` with your own Drupal backend._
 
 4. Start Nuxt: `npm run dev`
 

--- a/docs/nuxt/content/guide/multilingual.md
+++ b/docs/nuxt/content/guide/multilingual.md
@@ -5,7 +5,7 @@ weight: -5
 
 # Multilingual content
 
-Druxt has support for multilingual content in all modules and in various forms:
+Druxt has support for multilingual content in all modules:
 
 - The DruxtClient and Store can fetch translated resources and collections
 - Druxt module components can specify language with the **langcode** prop

--- a/docs/nuxt/content/guide/proxy.md
+++ b/docs/nuxt/content/guide/proxy.md
@@ -26,8 +26,8 @@ export default {
 };
 ```
 
-Two proxy items will be created, one for the JSON:API endpoint, and the other
-for the decoupled router.
+This creates two proxy items: one for the JSON:API endpoint, and one for the
+decoupled router.
 
 ---
 

--- a/docs/nuxt/content/modules/entity/README.md
+++ b/docs/nuxt/content/modules/entity/README.md
@@ -74,7 +74,7 @@ Renders a Drupal Content Entity form with submission and validation support.
 
 Entity query settings can be provided to include related resources and filter the returned fields.
 
-- **fields**: An array of strings, or array of arrays formatted for the Drupal JSON:API Params addFields method, used to filter the returned resources fields.
+- **fields**: An array of strings, or an array of arrays. Formatted for the Drupal JSON:API Params `addFields` method, used to filter the returned resource fields.
 - **include**: An array of relationship id's to include in the returned resources.
 - **schema**: Boolean, if `true` fields will be populated by the Drupal Display schema information.
 

--- a/docs/nuxt/content/modules/site/getting-started.md
+++ b/docs/nuxt/content/modules/site/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started with DruxtSite
 
 > DruxtSite gives you an out-of-the-box Drupal site experience with a Nuxt.js frontend.
 
-Think of the DruxtSite module as a distribution of Drupal, Nuxt and Druxt to provide a Vue.js theme layer for Drupal.
+DruxtSite combines Drupal, Nuxt and Druxt into a Vue.js theme layer for Drupal.
 
 ---
 
@@ -20,9 +20,9 @@ Try out a pre-installed, pre-configured DruxtSite install with GitPod.
 
 All Druxt sites need both Drupal (backend) and Nuxt (frontend) to be installed.
 
-Each codebase can live in its own directory within a single repository, or exist in separate repositories.
+Each codebase can live in its own directory within one repository, or exist in separate repositories.
 
-- For an example of a single repository, see the [Quickstart DruxtSite repository](https://github.com/druxt/quickstart-druxt-site).
+- For an example combining both into one repository, see the [Quickstart DruxtSite repository](https://github.com/druxt/quickstart-druxt-site).
 - For an example of individual repositories, see:
   - [Umami demo Nuxt repository](https://github.com/druxt/demo.druxtjs.org)
   - [Umami demo Drupal repository](https://github.com/druxt/demo-api.druxtjs.org)
@@ -73,7 +73,7 @@ Each codebase can live in its own directory within a single repository, or exist
    };
    ```
 
-   \* _**Note:** Replace `https://demo-api.druxtjs.org` with your own Drupal backend._
+   \* _Replace `https://demo-api.druxtjs.org` with your own Drupal backend._
 
 4. Add the `DruxtSite` component to your page or layout:
 


### PR DESCRIPTION
## Types of changes

- [x] New feature (a non-breaking change which adds functionality)

## Description

I keep hitting the same handful of AI-voice tics across our docs: em-dashes doing too much work, "leverage" standing in for "use", noun piles you have to read three times to parse. So I went looking for a linter built specifically for that, and found [vale-ai-tells](https://github.com/tbhb/vale-ai-tells), a [Vale](https://vale.sh) style package aimed squarely at it. This wires it into CI against `docs/nuxt/content`, downloading a checksum-verified Vale binary and syncing the style package on every run. `content/api/` and `content/modules/*/readme/` are skipped, both generated, neither is prose anyone actually wrote.

One rule fought back: `ai-tells.ColonUsage` flags any capitalized word after a colon, and our docs lean on exactly that shape everywhere - every module README's `**term**: Description` parameter list, `_Example: ..._` captions, `TODO:` markers, even "Druxt" itself ("TL;DR: Druxt = DRUpal + nUXT"). Vale's own docs call this a known limitation and say to disable the rule where that convention is established, so that's what I did, reasoning left in `.vale.ini` for the next person who finds it surprising.

Everything else it caught was real, so I fixed the prose instead of arguing with the tool: "leverage" became "use", a couple of empty modifiers got dropped, "a single repository" lost its redundant "single", a numbered lead-in and verb tricolon in `proxy.md` got rewritten, a noun-string pile in `devtools.md` got untangled, and a couple of "Think of X as" / "**Note:**" asides got cut. `entity/README.md`'s `fields` description tripped a genuine `VerbTricolon` false positive too, three comma clauses after a colon read as an asyndetic tricolon to the rule even with no "and"/"or" in sight, so that got rewritten as well.

Runs on every push and PR now, blocking, no `allow_failure` or `continue-on-error` anywhere. Nothing left to except.

## Checklist

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (content fixes are in this PR)
- [x] I have added tests to cover my changes (if not applicable, please state why): tooling/config change, verified end-to-end (checksum-verified binary download, `vale sync`, and a clean 0-error run against all 20 hand-authored content files)
- [x] All new and existing tests are passing.

## Screenshots/Media

N/A - CI config change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Druxt setup, repository organization, multilingual support, proxy behavior, and site integration.
  - Improved guidance for entity field filtering and deprecation details.
  - Refined formatting and wording across the documentation for greater clarity.

- **Quality Improvements**
  - Added automated prose-quality and style checks for documentation in CI.
  - Added validation for supported environments and download integrity.
  - Excluded generated and mirrored content from style validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->