### PR TITLE
feat(docs): replace the module card monograms with per-module icons

### DIFF
--- a/docs/nuxt/components/app/ModuleCard.vue
+++ b/docs/nuxt/components/app/ModuleCard.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="group rounded-box border border-base-300 bg-base-100 p-5 flex flex-col gap-3 hover:border-primary hover:shadow-lg transition-all">
     <div class="flex items-center gap-3">
-      <span class="w-9 h-9 rounded-btn bg-base-200 text-primary-focus grid place-items-center font-mono text-[11px] font-bold uppercase">
-        {{ abbr }}
+      <span class="w-9 h-9 rounded-btn bg-base-200 text-primary-focus grid place-items-center">
+        <component :is="icon" class="w-5 h-5" />
       </span>
       <h3 class="text-lg font-semibold" v-text="module.title" />
     </div>
@@ -18,6 +18,30 @@
 </template>
 
 <script>
+import Blocks from './icon/module/Blocks.vue'
+import Breadcrumb from './icon/module/Breadcrumb.vue'
+import Druxt from './icon/module/Druxt.vue'
+import Entity from './icon/module/Entity.vue'
+import Menu from './icon/module/Menu.vue'
+import Router from './icon/module/Router.vue'
+import Schema from './icon/module/Schema.vue'
+import Site from './icon/module/Site.vue'
+import Views from './icon/module/Views.vue'
+
+// Imported statically: the pick is dynamic by data, which auto-import
+// template scanning cannot see.
+const icons = {
+  blocks: Blocks,
+  breadcrumb: Breadcrumb,
+  druxt: Druxt,
+  entity: Entity,
+  menu: Menu,
+  router: Router,
+  schema: Schema,
+  site: Site,
+  views: Views,
+}
+
 export default {
   props: {
     /** A store.state.modules entry: { title, description, dir } */
@@ -26,7 +50,9 @@ export default {
 
   computed: {
     pkg: ({ module }) => module.dir.split('/')[2],
-    abbr: ({ module }) => module.title.replace(/[^a-z]/gi, '').slice(0, 3),
+
+    /** The module's icon component; the core mark covers unknown packages. */
+    icon: ({ pkg }) => icons[pkg] || Druxt,
   },
 }
 </script>

--- a/docs/nuxt/components/app/icon/module/Blocks.vue
+++ b/docs/nuxt/components/app/icon/module/Blocks.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect style="stroke: hsl(var(--pf))" x="3.5" y="4.5" width="17" height="15" rx="2" />
+    <path style="stroke: hsl(var(--pf))" d="M3.5 9.5h17" />
+    <path style="stroke: hsl(var(--sf))" d="M10.5 9.5v10" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Breadcrumb.vue
+++ b/docs/nuxt/components/app/icon/module/Breadcrumb.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path style="stroke: hsl(var(--pf))" d="M5 6.5l5.5 5.5L5 17.5M12.5 8.5l3.5 3.5-3.5 3.5" />
+    <path style="stroke: hsl(var(--sf))" d="M20 12h.01" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Druxt.vue
+++ b/docs/nuxt/components/app/icon/module/Druxt.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path style="stroke: hsl(var(--pf))" d="M21.5 19.25h-19L9.4 5.5l3.4 6.45" />
+    <path style="stroke: hsl(var(--sf))" d="M12.8 11.95l2.6-5.4 6.1 12.7" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Entity.vue
+++ b/docs/nuxt/components/app/icon/module/Entity.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect style="stroke: hsl(var(--pf))" x="3.5" y="5" width="17" height="14" rx="2" />
+    <circle style="stroke: hsl(var(--pf))" cx="8.25" cy="10.75" r="1.75" />
+    <path style="stroke: hsl(var(--sf))" d="M12.75 9.75H17M12.75 13.25H17M7 16.25h10" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Menu.vue
+++ b/docs/nuxt/components/app/icon/module/Menu.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path style="stroke: hsl(var(--pf))" d="M4.5 6h.01M4.5 12h.01M8 18h.01" />
+    <path style="stroke: hsl(var(--sf))" d="M9 6h10.5M9 12h10.5M12.5 18h7" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Router.vue
+++ b/docs/nuxt/components/app/icon/module/Router.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle style="stroke: hsl(var(--pf))" cx="5.75" cy="18.25" r="2.25" />
+    <path style="stroke: hsl(var(--pf))" d="M7.4 16.6c3.2-2.6 1.4-6.1 4.4-8.1 1.3-.87 2.5-.95 4.1-1.05" />
+    <circle style="stroke: hsl(var(--sf))" cx="18.25" cy="5.75" r="2.25" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Schema.vue
+++ b/docs/nuxt/components/app/icon/module/Schema.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path style="stroke: hsl(var(--pf))" d="M9.75 4.5C7.95 4.5 7 5.45 7 7.25v2.1c0 1.35-.85 2.25-2.5 2.65 1.65.4 2.5 1.3 2.5 2.65v2.1c0 1.8.95 2.75 2.75 2.75" />
+    <path style="stroke: hsl(var(--sf))" d="M14.25 4.5c1.8 0 2.75.95 2.75 2.75v2.1c0 1.35.85 2.25 2.5 2.65-1.65.4-2.5 1.3-2.5 2.65v2.1c0 1.8-.95 2.75-2.75 2.75" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Site.vue
+++ b/docs/nuxt/components/app/icon/module/Site.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect style="stroke: hsl(var(--pf))" x="3.5" y="4.5" width="17" height="15" rx="2" />
+    <path style="stroke: hsl(var(--pf))" d="M3.5 9h17M6.25 6.75h.01M8.75 6.75h.01" />
+    <path style="stroke: hsl(var(--sf))" d="M12 11.75l-2.6 4.75h5.2L12 11.75z" />
+  </svg>
+</template>

--- a/docs/nuxt/components/app/icon/module/Views.vue
+++ b/docs/nuxt/components/app/icon/module/Views.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect style="stroke: hsl(var(--pf))" x="4" y="4.25" width="4" height="4" rx="1" />
+    <rect style="stroke: hsl(var(--pf))" x="4" y="10" width="4" height="4" rx="1" />
+    <rect style="stroke: hsl(var(--pf))" x="4" y="15.75" width="4" height="4" rx="1" />
+    <path style="stroke: hsl(var(--sf))" d="M11.5 6.25H20M11.5 12H20M11.5 17.75H20" />
+  </svg>
+</template>


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The redesigned module cards use the first three letters of each module name as a stand-in mark. This replaces the stand-in with a proper icon for each module.

Each icon is a template-only Vue component in the existing Heroicons outline style, drawn on a 24px grid with a 2px stroke and hidden from screen readers. The colours follow the brand rule: blue for the Drupal side of each mark, green for the Nuxt side. They ride the daisyUI theme variables so both themes work without script, and fall back to currentColor. The card imports them statically and picks by package name, with the core Druxt mark as the fallback for anything unmapped. No new dependencies.

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

No new tests: the icons are template-only markup with no logic, and the docs e2e suite already covers the pages that render them.

## Screenshots/Media

<!--- Add any screenshots or other type of media to demonstrate your change -->
