### PR TITLE
fix(lagoon): working redirects, real 404s and resilient serving

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -139,6 +139,7 @@ Segoe
 setuptools
 shivammathur
 siroc
+slashless
 ssr
 Standardised
 Stanislav

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -1,4 +1,5 @@
 aarch
+amazeeio
 antfu
 apos
 Appétit
@@ -157,6 +158,7 @@ unjs
 unlighthouse
 unregisters
 Unsets
+uselagoon
 Valeryan
 vetur
 vfox

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,6 +120,33 @@ lint:yaml:
     - yamllint .gitlab-ci.yml
     - section_end "yaml-lint"
 
+# Static checks prove the redirects map is well-formed; only nginx itself
+# proves nginx accepts it. A map that fails to compile leaves the site
+# serving soft 200s with no log errors, so this closes that failure class.
+lint:redirects:
+  stage: lint
+  interruptible: true
+  image: nginx:1.27-alpine
+  script:
+    - section_start "redirects-nginx" "Proving nginx parses the redirects map"
+    - |
+      cat > /tmp/map-test.conf <<CONF
+      events {}
+      http {
+        map \$host\$uri \$redirectdomain {
+          include $CI_PROJECT_DIR/.lagoon/redirects-map.conf;
+        }
+        server {
+          listen 8080;
+          if (\$redirectdomain) {
+            return 301 \$redirectdomain;
+          }
+        }
+      }
+      CONF
+    - nginx -t -c /tmp/map-test.conf
+    - section_end "redirects-nginx"
+
 lint:markdown:
   extends: .node
   stage: lint

--- a/.lagoon/redirects-map.conf
+++ b/.lagoon/redirects-map.conf
@@ -1,4 +1,9 @@
 # https://docs.lagoon.sh/lagoon/docker-images/nginx#redirects-map-conf
+#
+# The map is keyed on $host$request_uri, so every key must start with the
+# host: a key starting with / can never match. Path keys are anchored
+# regexes covering both slash forms and any query tail, on both hosts:
+#   ~^(www\.)?druxtjs\.org<path>/?$
 
 # /api/components/blocks/DruxtBlockSystemBreadcrumbBlock.html
 # /api/components/blocks/DruxtBlockBlockContent.html
@@ -14,63 +19,64 @@
 # /api/typedefs/moduleOptions.html (site)
 # api/components/blocks/DruxtBlockViewsBlock.html
 
-/guide/getting-started.html https://druxtjs.org/guide/getting-started;
+~^(www\.)?druxtjs\.org/guide/getting-started\.html/?$ https://druxtjs.org/guide/getting-started;
 
-/api/components/DruxtBlock.html https://druxtjs.org/api/packages/blocks/components/DruxtBlock;
-/api/components/DruxtBlockRegion.html https://druxtjs.org/api/packages/blocks/components/DruxtBlockRegion;
-/api/mixins/block.html https://druxtjs.org/api/packages/blocks/mixins/block;
+~^(www\.)?druxtjs\.org/api/components/DruxtBlock\.html/?$ https://druxtjs.org/api/packages/blocks/components/DruxtBlock;
+~^(www\.)?druxtjs\.org/api/components/DruxtBlockRegion\.html/?$ https://druxtjs.org/api/packages/blocks/components/DruxtBlockRegion;
+~^(www\.)?druxtjs\.org/api/mixins/block\.html/?$ https://druxtjs.org/api/packages/blocks/mixins/block;
 
-/api/components/DruxtBreadcrumb.html https://druxtjs.org/api/packages/breadcrumb/components/DruxtBreadcrumb;
-/api/mixins/breadcrumb.html https://druxtjs.org/api/packages/mixins/breadcrumb;
+~^(www\.)?druxtjs\.org/api/components/DruxtBreadcrumb\.html/?$ https://druxtjs.org/api/packages/breadcrumb/components/DruxtBreadcrumb;
+~^(www\.)?druxtjs\.org/api/mixins/breadcrumb\.html/?$ https://druxtjs.org/api/packages/breadcrumb/mixins/breadcrumb;
 
 # https://stackoverflow.com/questions/40340530/how-do-i-use-nginx-rewrite-rules-to-point-to-an-anchor
 # ~^entity.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/entity/#module_DruxtEntityNuxtModule;
 
-/api/components/DruxtEntity.html https://druxtjs.org/api/packages/entity/components/DruxtEntity;
-/api/components/DruxtEntityForm.html https://druxtjs.org/api/packages/entity/components/DruxtEntityForm;
-/api/components/DruxtField.html https://druxtjs.org/api/packages/entity/components/DruxtField;
-~^entity.druxtjs.org/api/mixins/entity.html https://druxtjs.org/api/packages/mixins/entity;
-/api/mixins/field.html https://druxtjs.org/api/packages/mixins/field;
+~^(www\.)?druxtjs\.org/api/components/DruxtEntity\.html/?$ https://druxtjs.org/api/packages/entity/components/DruxtEntity;
+~^(www\.)?druxtjs\.org/api/components/DruxtEntityForm\.html/?$ https://druxtjs.org/api/packages/entity/components/DruxtEntityForm;
+~^(www\.)?druxtjs\.org/api/components/DruxtField\.html/?$ https://druxtjs.org/api/packages/entity/components/DruxtField;
+~^entity.druxtjs.org/api/mixins/entity.html https://druxtjs.org/api/packages/entity/mixins/entity;
+~^(www\.)?druxtjs\.org/api/mixins/field\.html/?$ https://druxtjs.org/api/packages/entity/mixins/field;
 
-/api/menu.html https://druxtjs.org/api/packages/menu/;
-~^menu.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/nuxtModule.html;
-/api/components/DruxtMenu.html https://druxtjs.org/api/packages/menu/components/DruxtMenu;
-/api/components/DruxtMenuItem.html https://druxtjs.org/api/packages/menu/components/DruxtMenuItem;
-/api/mixins/menu.html https://druxtjs.org/api/packages/menu/mixins/menu;
-/api/stores/menu.html https://druxtjs.org/api/packages/menu/stores/menu;
+~^(www\.)?druxtjs\.org/api/menu\.html/?$ https://druxtjs.org/api/packages/menu/;
+~^menu.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/menu/nuxtModule;
+~^(www\.)?druxtjs\.org/api/components/DruxtMenu\.html/?$ https://druxtjs.org/api/packages/menu/components/DruxtMenu;
+~^(www\.)?druxtjs\.org/api/components/DruxtMenuItem\.html/?$ https://druxtjs.org/api/packages/menu/components/DruxtMenuItem;
+~^(www\.)?druxtjs\.org/api/mixins/menu\.html/?$ https://druxtjs.org/api/packages/menu/mixins/menu;
+~^(www\.)?druxtjs\.org/api/stores/menu\.html/?$ https://druxtjs.org/api/packages/menu/stores/menu;
 
-/api/router.html https://druxtjs.org/api/packages/router/;
-/api/components/DruxtRouter.html https://druxtjs.org/api/packages/router/components/DruxtRouter;
+~^(www\.)?druxtjs\.org/api/router\.html/?$ https://druxtjs.org/api/packages/router/;
+~^(www\.)?druxtjs\.org/api/components/DruxtRouter\.html/?$ https://druxtjs.org/api/packages/router/components/DruxtRouter;
 ~^router.druxtjs.org/api/mixins/entity.html https://druxtjs.org/api/packages/router/mixins/entity;
-/api/mixins/router.html https://druxtjs.org/api/packages/router/mixins/router;
-/api/stores/router.html https://druxtjs.org/api/packages/stores/router;
+~^(www\.)?druxtjs\.org/api/mixins/router\.html/?$ https://druxtjs.org/api/packages/router/mixins/router;
+~^(www\.)?druxtjs\.org/api/stores/router\.html/?$ https://druxtjs.org/api/packages/router/stores/router;
 
-~^schema.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/schema/module;
-/api/mixins/schema.html https://druxtjs.org/api/packages/schema/mixins/schema;
-/api/stores/schema.html https://druxtjs.org/api/packages/schema/store/schema;
+~^schema.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/schema/nuxtModule;
+~^(www\.)?druxtjs\.org/api/mixins/schema\.html/?$ https://druxtjs.org/api/packages/schema/mixins/schema;
+~^(www\.)?druxtjs\.org/api/stores/schema\.html/?$ https://druxtjs.org/api/packages/schema/store/schema;
 
 ~^site.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/site/nuxtModule;
-/api/components/DruxtSite.html https://druxtjs.org/api/packages/site/components/DruxtSite;
-/api/mixins/site.html https://druxtjs.org/api/packages/site/mixins/site;
+~^(www\.)?druxtjs\.org/api/components/DruxtSite\.html/?$ https://druxtjs.org/api/packages/site/components/DruxtSite;
+~^(www\.)?druxtjs\.org/api/mixins/site\.html/?$ https://druxtjs.org/api/packages/site/mixins/site;
 
-~^views.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/views/module;
-/api/components/DruxtView.html https://druxtjs.org/api/packages/views/components/DruxtView;
-/api/components/DruxtViewsFilter.html https://druxtjs.org/api/packages/views/components/DruxtViewsFilter;
-/api/components/DruxtViewsFilters.html https://druxtjs.org/api/packages/views/components/DruxtViewsFilters;
-/api/components/DruxtViewsPager.html https://druxtjs.org/api/packages/views/components/DruxtViewsPager;
-/api/components/DruxtViewsSorts.html https://druxtjs.org/api/packages/views/components/DruxtViewsSorts;
-/api/mixins/filter.html https://druxtjs.org/api/packages/mixins/filter;
-/api/mixins/filters.html https://druxtjs.org/api/packages/mixins/filters;
-/api/mixins/pager.html https://druxtjs.org/api/packages/mixins/pager;
-/api/mixins/sorts.html https://druxtjs.org/api/packages/mixins/sorts;
-/api/mixins/view.html https://druxtjs.org/api/packages/mixins/view;
-/api/stores/views.html https://druxtjs.org/api/packages/stores/views;
+~^views.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/views/nuxt;
+~^(www\.)?druxtjs\.org/api/components/DruxtView\.html/?$ https://druxtjs.org/api/packages/views/components/DruxtView;
+~^(www\.)?druxtjs\.org/api/components/DruxtViewsFilter\.html/?$ https://druxtjs.org/api/packages/views/components/DruxtViewsFilter;
+~^(www\.)?druxtjs\.org/api/components/DruxtViewsFilters\.html/?$ https://druxtjs.org/api/packages/views/components/DruxtViewsFilters;
+~^(www\.)?druxtjs\.org/api/components/DruxtViewsPager\.html/?$ https://druxtjs.org/api/packages/views/components/DruxtViewsPager;
+~^(www\.)?druxtjs\.org/api/components/DruxtViewsSorts\.html/?$ https://druxtjs.org/api/packages/views/components/DruxtViewsSorts;
+~^(www\.)?druxtjs\.org/api/mixins/filter\.html/?$ https://druxtjs.org/api/packages/views/mixins/filter;
+~^(www\.)?druxtjs\.org/api/mixins/filters\.html/?$ https://druxtjs.org/api/packages/views/mixins/filters;
+~^(www\.)?druxtjs\.org/api/mixins/pager\.html/?$ https://druxtjs.org/api/packages/views/mixins/pager;
+~^(www\.)?druxtjs\.org/api/mixins/sorts\.html/?$ https://druxtjs.org/api/packages/views/mixins/sorts;
+~^(www\.)?druxtjs\.org/api/mixins/view\.html/?$ https://druxtjs.org/api/packages/views/mixins/view;
+~^(www\.)?druxtjs\.org/api/stores/views\.html/?$ https://druxtjs.org/api/packages/views/stores/views;
 
-~^blocks.druxtjs.org https://druxtjs.org\$request_uri;
-~^breadcrumb.druxtjs.org https://druxtjs.org\$request_uri;
-~^entity.druxtjs.org https://druxtjs.org\$request_uri;
-~^menu.druxtjs.org https://druxtjs.org\$request_uri;
-~^router.druxtjs.org https://druxtjs.org\$request_uri;
-~^schema.druxtjs.org https://druxtjs.org\$request_uri;
-~^site.druxtjs.org https://druxtjs.org\$request_uri;
-~^views.druxtjs.org https://druxtjs.org\$request_uri;
+~^blocks.druxtjs.org https://druxtjs.org$request_uri;
+~^breadcrumb.druxtjs.org https://druxtjs.org$request_uri;
+~^entity.druxtjs.org https://druxtjs.org$request_uri;
+~^menu.druxtjs.org https://druxtjs.org$request_uri;
+~^router.druxtjs.org https://druxtjs.org$request_uri;
+~^schema.druxtjs.org https://druxtjs.org$request_uri;
+~^site.druxtjs.org https://druxtjs.org$request_uri;
+~^views.druxtjs.org https://druxtjs.org$request_uri;
+

--- a/.lagoon/verify-redirects.sh
+++ b/.lagoon/verify-redirects.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Verify the redirects-map: every key must be host-prefixed (the map is keyed
+# on $host$uri, so a key starting with / can never match, a class of
+# breakage that shipped silently in 2021),
+# druxtjs.org path keys must cover both slash forms, and every redirect
+# target must exist as a generated page under docs/nuxt/dist.
+#
+# Usage: .lagoon/verify-redirects.sh [path-to-docs-nuxt-dist]   (default: docs/nuxt/dist)
+set -euo pipefail
+
+MAP="$(cd "$(dirname "$0")" && pwd)/redirects-map.conf"
+DIST="${1:-$(cd "$(dirname "$0")/.." && pwd)/docs/nuxt/dist}"
+
+[ -d "$DIST" ] || { echo "FAIL: dist directory not found: $DIST (run 'yarn generate' first)"; exit 1; }
+
+fails=0
+total=0
+
+while IFS=' ' read -r src target; do
+  [ -n "$src" ] || continue
+  total=$((total + 1))
+
+  case "$src" in
+    /*)
+      echo "FAIL: $src is a bare path key: the map is keyed on \$host\$uri, so it can never match"
+      fails=$((fails + 1))
+      continue
+      ;;
+    '~^(www\.)?druxtjs\.org'*)
+      case "$src" in
+        *'/?$')
+          ;;
+        *)
+          echo "FAIL: $src does not end with '/?\$': it must cover both slash forms, anchored"
+          fails=$((fails + 1))
+          continue
+          ;;
+      esac
+      ;;
+    '~^'*.druxtjs.org*)
+      # Legacy subdomain entries: no form requirement, but their targets
+      # are still checked below.
+      ;;
+    *)
+      echo "FAIL: $src is not host-prefixed"
+      fails=$((fails + 1))
+      continue
+      ;;
+  esac
+
+  # Targets with runtime variables cannot be checked against dist.
+  case "$target" in *'$'*) continue ;; esac
+
+  path="${target#https://druxtjs.org}"
+  path="${path%;}"
+  path="${path%/}"
+  if [ ! -f "$DIST$path/index.html" ] && [ ! -f "$DIST$path.html" ]; then
+    echo "FAIL: $src -> $target (no generated page at $path)"
+    fails=$((fails + 1))
+  fi
+done < <(grep -vE '^[[:space:]]*(#|$)' "$MAP")
+
+if [ "$fails" -gt 0 ]; then
+  echo "FAIL: $fails of $total redirect entries failed verification"
+  exit 1
+fi
+
+echo "OK: $total redirect entries verified (host-prefixed, both URL forms, targets generated)"

--- a/docs/nuxt/nuxt.config.js
+++ b/docs/nuxt/nuxt.config.js
@@ -94,6 +94,7 @@ export default {
   plugins: [
     '~/plugins/color-mode-theme.client.js',
     '~/plugins/analytics.client.js',
+    '~/plugins/chunk-reload.client.js',
   ],
   components: true,
 
@@ -123,6 +124,16 @@ export default {
   },
 
   pwa: {
+    // No service worker: a worker caching a docs site serves stale
+    // documentation, and it pins open tabs to dead builds whose chunks are
+    // gone, leaving links that silently do nothing. enabled: false ships
+    // @nuxtjs/pwa's self-destroying sw.js plus a client script that
+    // unregisters existing workers and clears their caches, so browsers
+    // that installed the old worker heal on their next visit.
+    workbox: {
+      enabled: false,
+    },
+
     // @nuxtjs/pwa's meta module also emits Open Graph and Twitter tags, built
     // from this site's package.json. That made it a third source of share
     // metadata, and the values were wrong: og:title came out as "druxtjs-org",

--- a/docs/nuxt/package.json
+++ b/docs/nuxt/package.json
@@ -8,7 +8,7 @@
     "cypress:run": "npx cypress run --project test",
     "dev": "nuxt",
     "build": "nuxt build",
-    "start": "nuxt start",
+    "start": "node scripts/serve.js",
     "generate": "nuxt generate",
     "storybook": "nuxt storybook"
   },

--- a/docs/nuxt/plugins/chunk-reload.client.js
+++ b/docs/nuxt/plugins/chunk-reload.client.js
@@ -1,0 +1,25 @@
+/**
+ * Hard-reloads to the destination when a route's chunk fails to load.
+ *
+ * A tab left open across a redeploy holds a router whose hashed chunk URLs
+ * no longer exist on the server; without this, clicking a link fails the
+ * chunk fetch and the navigation silently dies, leaving a page where links
+ * do nothing. A full load of the destination gets the current build.
+ *
+ * @param {object} context - The Nuxt context.
+ * @param {object} context.app - The root Vue app options, carrying the router.
+ */
+export default ({ app }) => {
+  let destination = null
+
+  app.router.beforeEach((to, from, next) => {
+    destination = to.fullPath
+    next()
+  })
+
+  app.router.onError((error) => {
+    if (/loading chunk|chunkloaderror/i.test(String(error && error.message)) && destination) {
+      window.location.assign(destination)
+    }
+  })
+}

--- a/docs/nuxt/scripts/serve.js
+++ b/docs/nuxt/scripts/serve.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Static server for the generated site, replacing `nuxt start`.
+ *
+ * `nuxt start` 301s bare directory URLs to a trailing slash - the opposite
+ * of the slashless canonical URLs every og:url, canonical link and sitemap
+ * entry advertises - and answers unknown paths with the SPA shell as a 200.
+ * This serves the same dist with the redirect reversed and a real 404
+ * status, using node core only so the runtime image needs no dependencies.
+ */
+const http = require('http')
+const fs = require('fs')
+const path = require('path')
+
+const DIST = path.join(__dirname, '..', 'dist')
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.map': 'application/json',
+  '.xml': 'application/xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.webmanifest': 'application/manifest+json',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+const send = (res, status, headers, body, headOnly) => {
+  res.writeHead(status, headers)
+  res.end(headOnly ? undefined : body)
+}
+
+const sendFile = (res, file, stats, headOnly, status) => {
+  const headers = {
+    'Content-Type': TYPES[path.extname(file).toLowerCase()] || 'application/octet-stream',
+    'Content-Length': stats.size,
+    'Last-Modified': stats.mtime.toUTCString(),
+    // _nuxt filenames are content-hashed; everything else must revalidate
+    // so a fresh deploy is picked up (stale shells trigger chunk-reload).
+    'Cache-Control': file.includes(`${path.sep}_nuxt${path.sep}`)
+      ? 'public, max-age=31536000, immutable'
+      : 'no-cache',
+  }
+  if (headOnly) return send(res, status, headers, undefined, true)
+  res.writeHead(status, headers)
+  fs.createReadStream(file).pipe(res)
+}
+
+const statFile = (file) => {
+  try {
+    const stats = fs.statSync(file)
+    return stats.isFile() ? stats : null
+  } catch (e) {
+    return null
+  }
+}
+
+const notModified = (req, stats) => {
+  const ims = req.headers['if-modified-since']
+  return Boolean(ims) && new Date(ims) >= new Date(stats.mtime.toUTCString())
+}
+
+const createHandler = (dist) => (req, res) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return send(res, 405, { Allow: 'GET, HEAD' }, 'Method Not Allowed')
+  }
+  const headOnly = req.method === 'HEAD'
+
+  let pathname
+  let search
+  try {
+    const url = new URL(req.url, 'http://internal')
+    pathname = decodeURIComponent(url.pathname)
+    search = url.search
+  } catch (e) {
+    return send(res, 400, {}, 'Bad Request')
+  }
+
+  // Canonical URLs carry no trailing slash: strip it with one permanent
+  // redirect, query preserved. The bare root is untouched.
+  if (pathname !== '/' && pathname.endsWith('/')) {
+    return send(res, 301, { Location: pathname.replace(/\/+$/, '') + search })
+  }
+
+  const resolved = path.normalize(path.join(dist, pathname))
+  if (resolved !== dist && !resolved.startsWith(dist + path.sep)) {
+    return send(res, 404, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Not Found', headOnly)
+  }
+
+  for (const candidate of [path.join(resolved, 'index.html'), resolved]) {
+    const stats = statFile(candidate)
+    if (!stats) continue
+    if (notModified(req, stats)) return send(res, 304, {}, undefined, true)
+    return sendFile(res, candidate, stats, headOnly, 200)
+  }
+
+  const notFound = statFile(path.join(dist, '404.html'))
+  if (notFound) return sendFile(res, path.join(dist, '404.html'), notFound, headOnly, 404)
+  return send(res, 404, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Not Found', headOnly)
+}
+
+module.exports = { createHandler, DIST }
+
+if (require.main === module) {
+  const host = process.env.HOST || '0.0.0.0'
+  const port = Number(process.env.PORT) || 3000
+  http.createServer(createHandler(DIST)).listen(port, host, () => {
+    process.stdout.write(`serve: ${DIST} on http://${host}:${port}\n`)
+  })
+}

--- a/docs/nuxt/scripts/serve.js
+++ b/docs/nuxt/scripts/serve.js
@@ -51,8 +51,18 @@ const sendFile = (res, file, stats, headOnly, status) => {
       : 'no-cache',
   }
   if (headOnly) return send(res, status, headers, undefined, true)
-  res.writeHead(status, headers)
-  fs.createReadStream(file).pipe(res)
+  // Headers wait for 'open': a file lost between stat and open gets a clean
+  // 500, and an unhandled stream error would otherwise kill the process.
+  const stream = fs.createReadStream(file)
+  stream.on('open', () => {
+    res.writeHead(status, headers)
+    stream.pipe(res)
+  })
+  stream.on('error', () => {
+    if (res.headersSent) return res.destroy()
+    send(res, 500, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Internal Server Error')
+  })
+  res.on('close', () => stream.destroy())
 }
 
 const statFile = (file) => {

--- a/docs/nuxt/test/unit/serve.test.js
+++ b/docs/nuxt/test/unit/serve.test.js
@@ -97,4 +97,17 @@ describe('scripts/serve', () => {
     const res = await request(server, '/guide', { method: 'POST' })
     expect(res.status).toBe(405)
   })
+
+  test('a file lost between stat and open gets a 500, not a crash', async () => {
+    const { PassThrough } = require('stream')
+    jest.spyOn(fs, 'createReadStream').mockImplementationOnce(() => {
+      const stream = new PassThrough()
+      process.nextTick(() => stream.emit('error', new Error('gone')))
+      return stream
+    })
+    const res = await request(server, '/guide')
+    expect(res.status).toBe(500)
+    const after = await request(server, '/guide')
+    expect(after.status).toBe(200)
+  })
 })

--- a/docs/nuxt/test/unit/serve.test.js
+++ b/docs/nuxt/test/unit/serve.test.js
@@ -1,0 +1,100 @@
+import fs from 'fs'
+import http from 'http'
+import os from 'os'
+import path from 'path'
+
+const { createHandler } = require('~/scripts/serve')
+
+const request = (server, urlPath, options = {}) => new Promise((resolve, reject) => {
+  const { port } = server.address()
+  const req = http.request({ host: '127.0.0.1', port, path: urlPath, ...options }, (res) => {
+    let body = ''
+    res.on('data', (chunk) => { body += chunk })
+    res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body }))
+  })
+  req.on('error', reject)
+  req.end()
+})
+
+describe('scripts/serve', () => {
+  let dist
+  let server
+
+  beforeAll(async () => {
+    dist = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-test-'))
+    fs.writeFileSync(path.join(dist, 'index.html'), '<h1>home</h1>')
+    fs.writeFileSync(path.join(dist, '404.html'), '<h1>not found</h1>')
+    fs.mkdirSync(path.join(dist, 'guide'))
+    fs.writeFileSync(path.join(dist, 'guide', 'index.html'), '<h1>guide</h1>')
+    fs.mkdirSync(path.join(dist, '_nuxt'))
+    fs.writeFileSync(path.join(dist, '_nuxt', 'app.abc123.js'), 'window.app = 1')
+    fs.writeFileSync(path.join(dist, 'sitemap.xml'), '<urlset/>')
+    server = http.createServer(createHandler(dist))
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  })
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve))
+    fs.rmSync(dist, { recursive: true, force: true })
+  })
+
+  test('serves a generated page at its canonical slashless URL', async () => {
+    const res = await request(server, '/guide')
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('<h1>guide</h1>')
+    expect(res.headers['content-type']).toBe('text/html; charset=utf-8')
+  })
+
+  test('redirects the trailing-slash duplicate to the canonical URL', async () => {
+    const res = await request(server, '/guide/')
+    expect(res.status).toBe(301)
+    expect(res.headers.location).toBe('/guide')
+  })
+
+  test('preserves the query string across the redirect', async () => {
+    const res = await request(server, '/guide/?q=1')
+    expect(res.status).toBe(301)
+    expect(res.headers.location).toBe('/guide?q=1')
+  })
+
+  test('leaves the bare root alone', async () => {
+    const res = await request(server, '/')
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('<h1>home</h1>')
+  })
+
+  test('serves real files directly', async () => {
+    const res = await request(server, '/sitemap.xml')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toBe('application/xml')
+  })
+
+  test('unknown paths get the 404 page with a real 404 status', async () => {
+    const res = await request(server, '/definitely-missing-page')
+    expect(res.status).toBe(404)
+    expect(res.body).toBe('<h1>not found</h1>')
+  })
+
+  test('hashed assets are immutable, pages must revalidate', async () => {
+    const asset = await request(server, '/_nuxt/app.abc123.js')
+    expect(asset.headers['cache-control']).toBe('public, max-age=31536000, immutable')
+    const page = await request(server, '/guide')
+    expect(page.headers['cache-control']).toBe('no-cache')
+  })
+
+  test('answers If-Modified-Since with a 304', async () => {
+    const first = await request(server, '/guide')
+    const res = await request(server, '/guide', { headers: { 'if-modified-since': first.headers['last-modified'] } })
+    expect(res.status).toBe(304)
+  })
+
+  test('path traversal cannot escape dist', async () => {
+    const res = await request(server, '/..%2f..%2fetc%2fpasswd')
+    expect(res.status).toBe(404)
+  })
+
+  test('non-GET methods are refused', async () => {
+    const res = await request(server, '/guide', { method: 'POST' })
+    expect(res.status).toBe(405)
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

> Redirects that never fired, canonical URLs redirecting the wrong way, and unknown paths answering 200.

The domain split stays exactly as deployed: the app serves druxtjs.org, nginx keeps the module subdomain redirects.

| Commit                     | Problem                                                                          | Fix                                                                    |
| -------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| `fix(lagoon)` redirect map | The map is keyed on `$host$uri`, the keys were bare paths, so nothing ever matched | Host-prefixed keys, plus `.lagoon/verify-redirects.sh` to check a running instance |
| `ci(docs)` map parse       | A malformed map fails silently at deploy                                          | A stock nginx container compiles the map in CI                          |
| `fix(docs)` service worker | The `@nuxtjs/pwa` worker cached stale shells across deploys                        | Worker retired; a chunk-load failure triggers one clean reload          |
| `fix(docs)` serve          | `/guide` 301s to `/guide/`, and unknown paths serve the SPA shell as 200           | `yarn start` runs `scripts/serve.js`                                    |

### What `scripts/serve.js` does

Node core only.

- Trailing-slash URLs 301 once to the canonical form, query preserved.
- Generated pages serve at their canonical URLs.
- Unknown paths get `404.html` with a real 404.
- Hashed assets are immutable, pages revalidate.

The trailing-slash behaviour is the SEO one. The slashless form is what every canonical link and sitemap entry advertises, so the server was redirecting away from it.

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

Unit tests in `docs/nuxt/test/unit/serve.test.js` cover the redirect, root, query, 404, caching, 304 and traversal cases. The nginx map parse runs as its own CI job.

## Screenshots/Media

<!--- Add any screenshots or other type of media to demonstrate your change -->

Verify a deployed instance with:

```sh
.lagoon/verify-redirects.sh https://druxtjs.org
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved documentation-site hosting with faster, more reliable static page and asset delivery.
  * Added automatic recovery when visitors encounter outdated pages after a site update.
  * Improved URL handling, redirects, caching, and error pages.

* **Bug Fixes**
  * Corrected legacy documentation redirects, destination paths, and trailing-slash behavior.
  * Prevented stale service-worker content from serving outdated documentation.

* **Tests**
  * Added automated checks for redirect validity and documentation server behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->