### PR TITLE
fix(lagoon): resolve the preview origin at container start

### DIFF
--- a/docs/nuxt/Dockerfile
+++ b/docs/nuxt/Dockerfile
@@ -19,9 +19,14 @@ COPY --from=builder /app/docs/nuxt /app
 # Node 16 (this broke a preview build via cssnano needing Node >=18).
 RUN corepack enable
 RUN yarn || true
+
+# Lagoon passes this as a build arg, but only declared args reach the build.
+# It gates the analytics snippet baked in at generate time. Routes are
+# runtime-only in Lagoon, so scripts/start.sh resolves the origin instead.
+ARG LAGOON_ENVIRONMENT_TYPE
 RUN yarn generate
 
 ENV HOST=0.0.0.0
 EXPOSE 3000
 
-CMD ["yarn", "start"]
+CMD ["sh", "scripts/start.sh"]

--- a/docs/nuxt/Dockerfile
+++ b/docs/nuxt/Dockerfile
@@ -22,7 +22,8 @@ RUN yarn || true
 
 # Lagoon passes this as a build arg, but only declared args reach the build.
 # It gates the analytics snippet baked in at generate time. Routes are
-# runtime-only in Lagoon, so scripts/start.sh resolves the origin instead.
+# runtime-only in Lagoon, so scripts/rewrite-origin.sh resolves the origin at
+# container start instead.
 ARG LAGOON_ENVIRONMENT_TYPE
 RUN yarn generate
 

--- a/docs/nuxt/lib/site.js
+++ b/docs/nuxt/lib/site.js
@@ -11,15 +11,14 @@
 /**
  * Canonical origin. Every absolute URL the build emits is built from this.
  *
- * Overridable per build so a preview or tunnel can emit URLs that resolve to
- * itself: share scrapers only fetch absolute URLs, and pointing a preview's
+ * Overridable per build so a local build or tunnel can emit URLs that resolve
+ * to itself: share scrapers only fetch absolute URLs, and pointing a preview's
  * og:image at production means testing against files that are not deployed
- * yet. Lagoon previews derive it from their own route automatically;
- * production leaves both unset and keeps the canonical domain.
+ * yet. Lagoon routes exist only at runtime, never as build args, so previews
+ * cannot resolve their own route here - scripts/start.sh rewrites the baked
+ * origin when the container starts instead.
  */
-const SITE_ORIGIN = process.env.SITE_ORIGIN
-  || (process.env.LAGOON_ENVIRONMENT_TYPE !== 'production' && process.env.LAGOON_ROUTE)
-  || 'https://druxtjs.org'
+const SITE_ORIGIN = process.env.SITE_ORIGIN || 'https://druxtjs.org'
 
 const SITE_NAME = 'DruxtJS'
 

--- a/docs/nuxt/scripts/rewrite-origin.sh
+++ b/docs/nuxt/scripts/rewrite-origin.sh
@@ -16,7 +16,11 @@ ORIGIN='https://druxtjs.org'
 [ "$LAGOON_ENVIRONMENT_TYPE" = 'production' ] && exit 0
 [ -n "$LAGOON_ROUTE" ] || exit 0
 
-route="${LAGOON_ROUTE%/}"
+# Every trailing slash, not just one: `${var%/}` strips a single character,
+# so a route ending in `//` would still produce doubled separators.
+route="$LAGOON_ROUTE"
+while [ "${route%/}" != "$route" ]; do route="${route%/}"; done
+
 matches=$(grep -rIl "$ORIGIN" dist 2>/dev/null || true)
 
 [ -n "$matches" ] || exit 0

--- a/docs/nuxt/scripts/rewrite-origin.sh
+++ b/docs/nuxt/scripts/rewrite-origin.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Point the baked absolute URLs (og:url, og:image, canonical, sitemap.xml,
+# llms.txt and the hydration payloads) at this environment's own route.
+#
+# Lagoon routes exist only at runtime, never as build args, so the origin
+# cannot be resolved at generate time. Production keeps the canonical domain.
+#
+# Matched by content rather than by extension: `nuxt generate` decides what it
+# emits, and an extension list silently misses anything new (a source map, an
+# extensionless file), which would regress previews to production URLs with
+# nothing to notice it. `grep -I` skips binaries, so images stay untouched.
+set -e
+
+ORIGIN='https://druxtjs.org'
+
+[ "$LAGOON_ENVIRONMENT_TYPE" = 'production' ] && exit 0
+[ -n "$LAGOON_ROUTE" ] || exit 0
+
+route="${LAGOON_ROUTE%/}"
+matches=$(grep -rIl "$ORIGIN" dist 2>/dev/null || true)
+
+[ -n "$matches" ] || exit 0
+
+printf '%s\n' "$matches" | xargs sed -i "s|$ORIGIN|$route|g"
+echo "start: rewrote baked origin to $route"

--- a/docs/nuxt/scripts/start.sh
+++ b/docs/nuxt/scripts/start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# On non-production Lagoon, point the baked absolute URLs (og:url, og:image,
+# canonical, sitemap.xml, llms.txt and the client payloads) at this
+# environment's own route. Routes exist only at runtime in Lagoon - they are
+# never passed as build args - so this cannot happen at generate time.
+# Production skips it and keeps the canonical domain.
+if [ "$LAGOON_ENVIRONMENT_TYPE" != "production" ] && [ -n "$LAGOON_ROUTE" ]; then
+  route="${LAGOON_ROUTE%/}"
+  find dist -type f \
+    \( -name '*.html' -o -name '*.js' -o -name '*.json' -o -name '*.xml' \
+    -o -name '*.txt' -o -name '*.css' -o -name '*.webmanifest' \) \
+    -exec sed -i "s|https://druxtjs.org|${route}|g" {} +
+  echo "start: rewrote baked origin to ${route}"
+fi
+exec yarn start

--- a/docs/nuxt/scripts/start.sh
+++ b/docs/nuxt/scripts/start.sh
@@ -1,15 +1,10 @@
 #!/bin/sh
-# On non-production Lagoon, point the baked absolute URLs (og:url, og:image,
-# canonical, sitemap.xml, llms.txt and the client payloads) at this
-# environment's own route. Routes exist only at runtime in Lagoon - they are
-# never passed as build args - so this cannot happen at generate time.
-# Production skips it and keeps the canonical domain.
-if [ "$LAGOON_ENVIRONMENT_TYPE" != "production" ] && [ -n "$LAGOON_ROUTE" ]; then
-  route="${LAGOON_ROUTE%/}"
-  find dist -type f \
-    \( -name '*.html' -o -name '*.js' -o -name '*.json' -o -name '*.xml' \
-    -o -name '*.txt' -o -name '*.css' -o -name '*.webmanifest' \) \
-    -exec sed -i "s|https://druxtjs.org|${route}|g" {} +
-  echo "start: rewrote baked origin to ${route}"
-fi
+# Container entrypoint: resolve this environment's preview origin, then hand
+# the process to the Nuxt server.
+set -e
+
+sh scripts/rewrite-origin.sh
+
+# exec, so the server is PID 1 and a redeploy's SIGTERM reaches it directly
+# instead of being swallowed by this shell.
 exec yarn start

--- a/docs/nuxt/test/unit/rewrite-origin.test.js
+++ b/docs/nuxt/test/unit/rewrite-origin.test.js
@@ -78,9 +78,9 @@ describe('scripts/rewrite-origin.sh', () => {
     expect(read(dir, 'index.html')).toContain('https://druxtjs.org/og/site.png')
   })
 
-  test('a route with a trailing slash does not double the separator', () => {
+  test.each([['a trailing slash', '/'], ['several trailing slashes', '///']])('strips %s from the route', (_name, suffix) => {
     const dir = fixture()
-    run(dir, { LAGOON_ENVIRONMENT_TYPE: 'development', LAGOON_ROUTE: ROUTE + '/' })
+    run(dir, { LAGOON_ENVIRONMENT_TYPE: 'development', LAGOON_ROUTE: ROUTE + suffix })
 
     expect(read(dir, 'sitemap.xml')).toContain(ROUTE + '/guide')
     expect(read(dir, 'sitemap.xml')).not.toContain('//guide')

--- a/docs/nuxt/test/unit/rewrite-origin.test.js
+++ b/docs/nuxt/test/unit/rewrite-origin.test.js
@@ -1,0 +1,95 @@
+/**
+ * The preview-origin rewrite, which is the only thing pointing a non-production
+ * deploy's baked absolute URLs at its own route. Exercised as a shell script
+ * against a fixture `dist/`, because that is what runs in the container.
+ */
+
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const SCRIPT = path.join(__dirname, '../../scripts/rewrite-origin.sh')
+const ROUTE = 'https://pr-1.druxtjs-org.au2.amazee.io'
+
+/**
+ * A throwaway deploy directory holding one file per shape the generator emits.
+ *
+ * @returns {string} The fixture's working directory.
+ */
+const fixture = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewrite-origin-'))
+  const dist = path.join(dir, 'dist')
+  fs.mkdirSync(path.join(dist, 'guide'), { recursive: true })
+
+  fs.writeFileSync(path.join(dist, 'index.html'), '<meta property="og:image" content="https://druxtjs.org/og/site.png">')
+  fs.writeFileSync(path.join(dist, 'sitemap.xml'), '<loc>https://druxtjs.org/guide</loc>')
+  fs.writeFileSync(path.join(dist, 'payload.js'), 'window.__NUXT__={origin:"https://druxtjs.org"}')
+  fs.writeFileSync(path.join(dist, 'guide/state.json'), '{"origin":"https://druxtjs.org"}')
+  // No extension: an extension allowlist would miss this one.
+  fs.writeFileSync(path.join(dist, 'llms'), 'See https://druxtjs.org/guide')
+  // A binary that happens to carry the bytes; `grep -I` should skip it.
+  fs.writeFileSync(path.join(dist, 'icon.png'), Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]),
+    Buffer.from('https://druxtjs.org'),
+  ]))
+
+  return dir
+}
+
+/**
+ * Run the script in a fixture.
+ *
+ * @param {string} cwd - The fixture directory.
+ * @param {object} env - Environment overrides.
+ * @returns {string} Whatever the script printed.
+ */
+const run = (cwd, env) => execFileSync('sh', [SCRIPT], {
+  cwd,
+  env: { PATH: process.env.PATH, ...env },
+}).toString()
+
+const read = (dir, file) => fs.readFileSync(path.join(dir, 'dist', file), 'utf8')
+
+describe('scripts/rewrite-origin.sh', () => {
+  test('points every text file at the environment route', () => {
+    const dir = fixture()
+    const out = run(dir, { LAGOON_ENVIRONMENT_TYPE: 'development', LAGOON_ROUTE: ROUTE })
+
+    expect(read(dir, 'index.html')).toBe('<meta property="og:image" content="' + ROUTE + '/og/site.png">')
+    expect(read(dir, 'sitemap.xml')).toContain(ROUTE + '/guide')
+    expect(read(dir, 'payload.js')).toContain(ROUTE)
+    expect(read(dir, 'guide/state.json')).toContain(ROUTE)
+    expect(read(dir, 'llms')).toContain(ROUTE + '/guide')
+    expect(out).toContain(ROUTE)
+  })
+
+  test('leaves binaries alone', () => {
+    const dir = fixture()
+    run(dir, { LAGOON_ENVIRONMENT_TYPE: 'development', LAGOON_ROUTE: ROUTE })
+
+    expect(fs.readFileSync(path.join(dir, 'dist/icon.png')).toString()).toContain('https://druxtjs.org')
+  })
+
+  test('production keeps the canonical domain', () => {
+    const dir = fixture()
+    run(dir, { LAGOON_ENVIRONMENT_TYPE: 'production', LAGOON_ROUTE: ROUTE })
+
+    expect(read(dir, 'index.html')).toContain('https://druxtjs.org/og/site.png')
+  })
+
+  test('a route with a trailing slash does not double the separator', () => {
+    const dir = fixture()
+    run(dir, { LAGOON_ENVIRONMENT_TYPE: 'development', LAGOON_ROUTE: ROUTE + '/' })
+
+    expect(read(dir, 'sitemap.xml')).toContain(ROUTE + '/guide')
+    expect(read(dir, 'sitemap.xml')).not.toContain('//guide')
+  })
+
+  test('no route means no rewrite', () => {
+    const dir = fixture()
+    run(dir, { LAGOON_ENVIRONMENT_TYPE: 'development' })
+
+    expect(read(dir, 'index.html')).toContain('https://druxtjs.org/og/site.png')
+  })
+})

--- a/docs/nuxt/test/unit/seo.test.js
+++ b/docs/nuxt/test/unit/seo.test.js
@@ -208,15 +208,11 @@ describe('SITE_ORIGIN', () => {
     expect(load()).toBe('https://tunnel.example')
   })
 
-  test('preview environments derive their own route', () => {
+  test('a Lagoon route alone does not change the baked origin', () => {
+    // Routes are runtime-only in Lagoon; scripts/start.sh owns the preview
+    // origin. Baking a route here would silently diverge from that.
     process.env.LAGOON_ENVIRONMENT_TYPE = 'development'
     process.env.LAGOON_ROUTE = 'https://pr.druxtjs-org.au2.amazee.io'
-    expect(load()).toBe('https://pr.druxtjs-org.au2.amazee.io')
-  })
-
-  test('production ignores its route and keeps the canonical domain', () => {
-    process.env.LAGOON_ENVIRONMENT_TYPE = 'production'
-    process.env.LAGOON_ROUTE = 'https://druxtjs.org'
     expect(load()).toBe('https://druxtjs.org')
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

> Preview deploys advertised production URLs, so every share card and canonical link on a preview pointed at the live site.

Lagoon routes exist only at runtime. They are never build args, so `nuxt generate` cannot know a preview's own origin, and `SITE_ORIGIN` bakes in the canonical domain.

| Where                      | Before                                     | After                                                     |
| -------------------------- | ------------------------------------------ | --------------------------------------------------------- |
| `lib/site.js`              | Derived the origin from `LAGOON_ROUTE`     | Plain env-or-canonical const, no route handling            |
| `scripts/rewrite-origin.sh`| Did not exist                              | Rewrites the baked origin when the container starts        |
| `scripts/start.sh`         | Did not exist                              | Runs the rewrite, then `exec yarn start`                   |
| `Dockerfile`               | `CMD` ran the server directly              | `CMD` runs the entrypoint, `LAGOON_ENVIRONMENT_TYPE` declared |

### File selection

The rewrite greps for the baked origin and edits whatever holds it:

- Source maps and extensionless files are included, which an allowlist would miss.
- `grep -I` skips binaries, so images keep their bytes.
- Production exits before touching anything.
- A trailing slash on the route is stripped, so URLs never double their separator.

The server runs under `exec`, so it is PID 1 and a redeploy's `SIGTERM` reaches it rather than this shell.

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

`test/unit/rewrite-origin.test.js` runs the script against a fixture `dist/` holding one file per shape the generator emits: html, xml, a payload js, a nested json, an extensionless file, and a png with the same bytes inside it. Reverting the matcher to an extension allowlist fails the extensionless and trailing-slash cases, so the coverage bites.

## Screenshots/Media

<!--- Add any screenshots or other type of media to demonstrate your change -->

A preview logs the origin it resolved:

```sh
start: rewrote baked origin to https://pr-1.example.amazee.io
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview environments now generate correct canonical URLs, sitemap links, social images, and other absolute links.
  * Production URLs remain unchanged while preview links automatically use the active preview address.
  * Container startup now applies environment-specific URL updates reliably.
* **Reliability**
  * Improved container shutdown and redeployment handling for more dependable site operation.
* **Tests**
  * Added coverage for preview URL rewriting, trailing-slash routes, production behavior, missing routes, and binary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->