### PR TITLE
docs(how-to): backend preparation, CORS and request topology

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -134,6 +134,7 @@ reskins
 Resvg
 resvg
 router
+safelisted
 satori
 scaffolder
 scule

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -59,6 +59,7 @@ felixfbecker
 filesystems
 Fraunces
 freetype
+frontends
 frontpage
 fullpath
 giget
@@ -121,6 +122,7 @@ PKCE
 pkill
 prebuilds
 preconfigured
+preflighted
 Quickstart
 quickstarts
 recognise
@@ -133,6 +135,7 @@ Resvg
 resvg
 router
 satori
+scaffolder
 scule
 Segoe
 segoe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
             packages/*/dist
             packages/*/CHANGELOG.md
             docs/nuxt/content/api
+            docs/nuxt/content/components
             docs/nuxt/content/modules/*/README.md
+            docs/nuxt/content/how-to/contributing.md
           retention-days: 1
 
   lint:
@@ -447,6 +449,15 @@ jobs:
           test "$readmes" -gt 0 || {
             echo "No docs/nuxt/content/modules/*/README.md after downloading build-output." >&2
             echo "Module pages render these as their body; generating without them fails the route guard." >&2
+            exit 1
+          }
+          test -d docs/nuxt/content/components || {
+            echo "docs/nuxt/content/components missing after downloading build-output." >&2
+            echo "The /components section fails the route guard without it." >&2
+            exit 1
+          }
+          test -f docs/nuxt/content/how-to/contributing.md || {
+            echo "docs/nuxt/content/how-to/contributing.md missing after downloading build-output." >&2
             exit 1
           }
           echo "API reference: $(find docs/nuxt/content/api -name '*.md' | wc -l) generated pages"

--- a/docs/nuxt/content/explanation/README.md
+++ b/docs/nuxt/content/explanation/README.md
@@ -21,3 +21,5 @@ instructions. For doing, see the [How-to guides](/how-to).
   data source.
 - [Component resolution](/explanation/component-resolution): wrapper
   discovery and the theme layer.
+- [Request topology](/explanation/request-topology): build, server and
+  browser requests, and what that means for CORS, the proxy and hosting.

--- a/docs/nuxt/content/explanation/architecture.md
+++ b/docs/nuxt/content/explanation/architecture.md
@@ -57,9 +57,10 @@ order:
 | Everything at once | `druxt-site`                                                    | Opinionated bundle: a working site layout out of the box             |
 
 On the Drupal side, the [`druxt`](https://www.drupal.org/project/druxt)
-module is the only required piece (it adds the permissions and path
-translators). `decoupled_router`, `jsonapi_menu_items` and `jsonapi_views`
-are Drupal dependencies of the matching frontend modules.
+module is the only piece to install (it adds the permissions and path
+translators). It depends on `decoupled_router`, `jsonapi_menu_items` and
+`jsonapi_views`, so composer and Drupal bring those in with it. See
+[Prepare the Drupal backend](/how-to/prepare-the-backend).
 
 ## Why this shape
 

--- a/docs/nuxt/content/explanation/request-topology.md
+++ b/docs/nuxt/content/explanation/request-topology.md
@@ -15,7 +15,7 @@ knowing which of the three is failing.
 | ------- | ---------------- | ---- | ---------------- |
 | Build | The Node process running `nuxt build` or `nuxt generate` | Once, at build time | No |
 | Server rendering | The Node server rendering a page | On each uncached page request | No |
-| Browser | The visitor's browser, after hydration | On client-side navigation and dynamic data | Yes |
+| Browser | The visitor's browser, after hydration | On client-side navigation and dynamic data | Yes, when calling Drupal directly cross-origin |
 
 CORS is a browser security mechanism. Requests made by Node, at build time
 or during server rendering, are ordinary server-to-server HTTP and are
@@ -40,8 +40,9 @@ the page so the browser does not refetch it. See
 
 **In the browser**, client-side navigation fetches new routes and resources
 directly from the JSON:API endpoint, and dynamic features (forms, search,
-authenticated content) make live requests. These are the requests CORS
-applies to.
+authenticated content) make live requests. CORS applies to these when
+they go straight to Drupal on another origin; routed through the proxy,
+they stay same-origin.
 
 ## CORS and the proxy are alternatives
 
@@ -63,7 +64,7 @@ must reach Drupal needs CORS configured in Drupal, full stop.
 | Layout | Example | Notes |
 | ------ | ------- | ----- |
 | Separate hosts | `example.com` + `cms.example.io` | The common case. Browser requests are cross-origin: configure CORS or run the proxy. |
-| Subdomains | `example.com` + `cms.example.com` | Still cross-origin for CORS purposes, but cookies can be shared across the parent domain, which simplifies authenticated flows. |
+| Subdomains | `example.com` + `cms.example.com` | Still cross-origin for CORS purposes: direct browser requests need credentialed CORS with the explicit origin listed. Cookies can be shared across the parent domain, which helps authenticated flows, but shared cookies do not make the hosts same-origin. |
 | Same origin | One domain, a reverse proxy routes `/jsonapi` and `/router` to Drupal | No CORS at all. The routing lives in your web server rather than in Druxt. |
 
 Drupal and Nuxt are always two applications with two document roots, even

--- a/docs/nuxt/content/explanation/request-topology.md
+++ b/docs/nuxt/content/explanation/request-topology.md
@@ -9,21 +9,21 @@ Requests flow between them at three different times, from three different
 places. Most "it works locally but not deployed" problems come from not
 knowing which of the three is failing.
 
-## The three request contexts
+## The request contexts
 
-| Context | Who calls Drupal | When | Subject to CORS? |
-| ------- | ---------------- | ---- | ---------------- |
-| Build | The Node process running `nuxt build` or `nuxt generate` | Once, at build time | No |
-| Server rendering | The Node server rendering a page | On each uncached page request | No |
-| Browser | The visitor's browser, after hydration | On client-side navigation and dynamic data | Yes, when calling Drupal directly cross-origin |
+| Context          | Who calls Drupal                                         | When                                    | Subject to CORS?                               |
+| ---------------- | -------------------------------------------------------- | --------------------------------------- | ---------------------------------------------- |
+| Build            | The Node process running `nuxt build` or `nuxt generate` | Once, at build time                     | No                                             |
+| Server rendering | The Node server rendering a page                         | On each uncached page request           | No                                             |
+| Browser          | The visitor's browser, after hydration                   | On client-side navigation and live data | Yes, when calling Drupal directly cross-origin |
 
 CORS is a browser security mechanism. Requests made by Node, at build time
 or during server rendering, are ordinary server-to-server HTTP and are
-never blocked by CORS. Only the third row can produce a CORS error.
-
-This is why a site can build cleanly and render its first page, then fail
-the moment a visitor clicks a link: the first two contexts worked, and the
-browser context did not.
+never blocked by CORS. Hydration is the moment the browser's JavaScript
+takes over the server-rendered page and makes it interactive; everything
+the page fetches after that point is a browser request. So a site can
+build cleanly, render its first page, and still fail the moment a
+visitor clicks a link.
 
 ## What happens in each context
 
@@ -34,13 +34,14 @@ changes in Drupal need a rebuild or a dev-server restart to appear. See
 [The schema system](/explanation/schemas).
 
 **During server rendering**, the DruxtStore fetches routes, entities,
-blocks and menus from Drupal, renders HTML, and serializes the store into
-the page so the browser does not refetch it. See
+blocks and menus from Drupal and renders the HTML. The store serializes
+into the page, so the browser does not refetch what the server already
+has. See
 [The DruxtStore](/explanation/druxt-store).
 
 **In the browser**, client-side navigation fetches new routes and resources
-directly from the JSON:API endpoint, and dynamic features (forms, search,
-authenticated content) make live requests. CORS applies to these when
+directly from the JSON:API endpoint, and forms, search and
+authenticated content make live requests. CORS applies to these when
 they go straight to Drupal on another origin; routed through the proxy,
 they stay same-origin.
 
@@ -49,23 +50,23 @@ they stay same-origin.
 When the frontend and backend live on different origins, browser requests
 to Drupal need one of two things:
 
-| Approach | How it works | Use it when |
-| -------- | ------------ | ----------- |
-| [Configure CORS in Drupal](/how-to/configure-cors) | Drupal sends `Access-Control-Allow-Origin` headers, and the browser talks to it directly | You serve a static site, or you want the backend to answer any frontend |
-| [The API proxy](/how-to/proxy) | The Nuxt server forwards `/jsonapi` and router requests to Drupal, so the browser only ever talks to the frontend origin | You run a Nuxt server (`nuxt dev` or `nuxt start`) and want single-origin simplicity |
+| Approach                                           | How it works                                                                                                             | Use it when                                                                          |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| [Configure CORS in Drupal](/how-to/configure-cors) | Drupal sends `Access-Control-Allow-Origin` headers, and the browser talks to it directly                                 | You serve a static site, or you want the backend to answer any frontend              |
+| [The API proxy](/how-to/proxy)                     | The Nuxt server forwards `/jsonapi` and router requests to Drupal, so the browser only ever talks to the frontend origin | You run a Nuxt server (`nuxt dev` or `nuxt start`) and want single-origin simplicity |
 
-One important limit: **the proxy is server middleware. It does not exist in
-a generated static site.** `nuxt generate` output is plain files; there is
+**The proxy is server middleware, and it does not exist in a generated
+static site.** `nuxt generate` output is plain files; there is
 no Nuxt server to forward requests. A static site whose browser requests
-must reach Drupal needs CORS configured in Drupal, full stop.
+must reach Drupal needs CORS configured in Drupal.
 
 ## Hosting layouts
 
-| Layout | Example | Notes |
-| ------ | ------- | ----- |
-| Separate hosts | `example.com` + `cms.example.io` | The common case. Browser requests are cross-origin: configure CORS or run the proxy. |
-| Subdomains | `example.com` + `cms.example.com` | Still cross-origin for CORS purposes: direct browser requests need credentialed CORS with the explicit origin listed. Cookies can be shared across the parent domain, which helps authenticated flows, but shared cookies do not make the hosts same-origin. |
-| Same origin | One domain, a reverse proxy routes `/jsonapi` and `/router` to Drupal | No CORS at all. The routing lives in your web server rather than in Druxt. |
+| Layout         | Example                                                               | Notes                                                                                                                                                                                                              |
+| -------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Separate hosts | `example.com` + `cms.example.io`                                      | The common case. Browser requests are cross-origin: configure CORS or run the proxy.                                                                                                                               |
+| Subdomains     | `example.com` + `cms.example.com`                                     | Still cross-origin for CORS purposes: direct browser requests need credentialed CORS with the explicit origin listed. Parent-domain cookie sharing helps authenticated flows without making the hosts same-origin. |
+| Same origin    | One domain, a reverse proxy routes `/jsonapi` and `/router` to Drupal | No CORS at all. The routing is defined in your web server's config rather than in Druxt.                                                                                                                           |
 
 Drupal and Nuxt are always two applications with two document roots, even
 when one repository holds both. "Hosted together" means a reverse proxy or
@@ -74,8 +75,9 @@ Drupal.
 
 ## baseUrl rules
 
-Every Druxt module takes a `baseUrl`. Three rules prevent the most common
-misconfigurations:
+Every Druxt module (the Nuxt-side packages configured in
+`nuxt.config.js`, not the Drupal module) takes a `baseUrl`. The rules
+that prevent the most common misconfigurations:
 
 - No trailing slash: `https://cms.example.com`, not
   `https://cms.example.com/`.
@@ -97,3 +99,10 @@ it), while subdomain and same-origin layouts can share cookies. If
 authentication matters to your site, pick the layout first. A deployment
 models overview covering how these choices combine arrives with the
 deployment guides.
+
+## Where to go next
+
+- [Configure CORS in Drupal](/how-to/configure-cors) and
+  [Proxy the Drupal backend](/how-to/proxy): the two implementations.
+- [Troubleshoot common issues](/how-to/troubleshooting): the failure
+  modes this topology produces.

--- a/docs/nuxt/content/explanation/request-topology.md
+++ b/docs/nuxt/content/explanation/request-topology.md
@@ -1,0 +1,98 @@
+---
+title: Request topology
+weight: -4
+description: 'Which requests happen at build time, during server rendering and in the browser, and what that means for CORS, the proxy and your hosting layout.'
+---
+
+A Druxt site is two applications: a Drupal backend and a Nuxt frontend.
+Requests flow between them at three different times, from three different
+places. Most "it works locally but not deployed" problems come from not
+knowing which of the three is failing.
+
+## The three request contexts
+
+| Context | Who calls Drupal | When | Subject to CORS? |
+| ------- | ---------------- | ---- | ---------------- |
+| Build | The Node process running `nuxt build` or `nuxt generate` | Once, at build time | No |
+| Server rendering | The Node server rendering a page | On each uncached page request | No |
+| Browser | The visitor's browser, after hydration | On client-side navigation and dynamic data | Yes |
+
+CORS is a browser security mechanism. Requests made by Node, at build time
+or during server rendering, are ordinary server-to-server HTTP and are
+never blocked by CORS. Only the third row can produce a CORS error.
+
+This is why a site can build cleanly and render its first page, then fail
+the moment a visitor clicks a link: the first two contexts worked, and the
+browser context did not.
+
+## What happens in each context
+
+**At build time**, Druxt fetches every entity schema from Drupal and writes
+them to static JSON files. There are no schema requests after startup; if
+the backend is unreachable during a build, the build fails. Display-mode
+changes in Drupal need a rebuild or a dev-server restart to appear. See
+[The schema system](/explanation/schemas).
+
+**During server rendering**, the DruxtStore fetches routes, entities,
+blocks and menus from Drupal, renders HTML, and serializes the store into
+the page so the browser does not refetch it. See
+[The DruxtStore](/explanation/druxt-store).
+
+**In the browser**, client-side navigation fetches new routes and resources
+directly from the JSON:API endpoint, and dynamic features (forms, search,
+authenticated content) make live requests. These are the requests CORS
+applies to.
+
+## CORS and the proxy are alternatives
+
+When the frontend and backend live on different origins, browser requests
+to Drupal need one of two things:
+
+| Approach | How it works | Use it when |
+| -------- | ------------ | ----------- |
+| [Configure CORS in Drupal](/how-to/configure-cors) | Drupal sends `Access-Control-Allow-Origin` headers, and the browser talks to it directly | You serve a static site, or you want the backend to answer any frontend |
+| [The API proxy](/how-to/proxy) | The Nuxt server forwards `/jsonapi` and router requests to Drupal, so the browser only ever talks to the frontend origin | You run a Nuxt server (`nuxt dev` or `nuxt start`) and want single-origin simplicity |
+
+One important limit: **the proxy is server middleware. It does not exist in
+a generated static site.** `nuxt generate` output is plain files; there is
+no Nuxt server to forward requests. A static site whose browser requests
+must reach Drupal needs CORS configured in Drupal, full stop.
+
+## Hosting layouts
+
+| Layout | Example | Notes |
+| ------ | ------- | ----- |
+| Separate hosts | `example.com` + `cms.example.io` | The common case. Browser requests are cross-origin: configure CORS or run the proxy. |
+| Subdomains | `example.com` + `cms.example.com` | Still cross-origin for CORS purposes, but cookies can be shared across the parent domain, which simplifies authenticated flows. |
+| Same origin | One domain, a reverse proxy routes `/jsonapi` and `/router` to Drupal | No CORS at all. The routing lives in your web server rather than in Druxt. |
+
+Drupal and Nuxt are always two applications with two document roots, even
+when one repository holds both. "Hosted together" means a reverse proxy or
+platform routes one domain to both; it never means installing Nuxt inside
+Drupal.
+
+## baseUrl rules
+
+Every Druxt module takes a `baseUrl`. Three rules prevent the most common
+misconfigurations:
+
+- No trailing slash: `https://cms.example.com`, not
+  `https://cms.example.com/`.
+- The `endpoint` option (default `/jsonapi`) starts with a slash and does
+  not end with one.
+- The URL must be reachable **from wherever the request runs**. A Docker
+  hostname like `http://drupal` resolves inside the build container but not
+  in a visitor's browser; a `localhost` URL means the visitor's own
+  machine, not your server. If the two contexts need different URLs, route
+  browser traffic through the proxy or a same-origin layout so one URL
+  serves both.
+
+## Cookies and sessions
+
+Authenticated flows ride on the same topology. Tokens and cookies issued by
+Drupal are scoped to Drupal's origin: a separate-host layout needs the
+frontend to send credentials cross-origin (and CORS configured to allow
+it), while subdomain and same-origin layouts can share cookies. If
+authentication matters to your site, pick the layout first. A deployment
+models overview covering how these choices combine arrives with the
+deployment guides.

--- a/docs/nuxt/content/how-to/README.md
+++ b/docs/nuxt/content/how-to/README.md
@@ -11,6 +11,8 @@ tutorial](/tutorials/getting-started).
 
 ## Guides
 
+- [Prepare the Drupal backend](/how-to/prepare-the-backend): modules, permissions and JSON:API settings for a Druxt-ready site.
+- [Configure CORS in Drupal](/how-to/configure-cors): let the browser talk to the backend directly.
 - [Serve content in multiple languages](/how-to/multilingual): fetch and render translated content.
 - [Proxy the Drupal backend through Nuxt](/how-to/proxy): prevent CORS issues.
 - [Theme Druxt components](/how-to/theming): customize output with wrappers and slots.

--- a/docs/nuxt/content/how-to/configure-cors.md
+++ b/docs/nuxt/content/how-to/configure-cors.md
@@ -1,0 +1,94 @@
+---
+title: Configure CORS in Drupal
+weight: -7
+description: Allow the browser to talk to the backend directly by serving CORS headers from Drupal, instead of proxying through the frontend.
+---
+
+> **Before you start:** read [Request
+> topology](/explanation/request-topology) to confirm CORS is what you
+> need. Only browser requests are subject to CORS; build and server
+> rendering failures have other causes.
+
+When the frontend and backend are on different origins, the browser blocks
+cross-origin JSON:API requests unless Drupal answers with CORS headers.
+This is the direct fix. The alternative, [proxying through the
+frontend](/how-to/proxy), avoids CORS but only works while a Nuxt server
+is running; a generated static site needs CORS.
+
+The Druxt Drupal module enables CORS by default when it is otherwise
+disabled, which is enough for anonymous reads. It does not set the
+allowed methods, so preflighted requests (form submissions, and any
+request carrying an `Authorization` header) can still fail until you
+configure the block below explicitly. Explicit configuration always
+wins, and is what production sites should ship.
+
+## Enable cors.config
+
+Drupal core ships the configuration disabled in
+`sites/default/default.services.yml`. Copy the file to
+`sites/default/services.yml` if it does not exist, and set the
+`cors.config` block:
+
+```yaml
+parameters:
+  cors.config:
+    enabled: true
+    allowedHeaders: ['*']
+    allowedMethods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS']
+    allowedOrigins: ['https://www.example.com']
+    exposedHeaders: false
+    maxAge: 1000
+    supportsCredentials: false
+```
+
+Then rebuild caches:
+
+```sh
+drush cache:rebuild
+```
+
+Three keys matter most:
+
+- `allowedOrigins` is your frontend origin, scheme included, no trailing
+  slash. List each environment that needs access (production, previews,
+  `http://localhost:3000` for local development), or use `['*']` while
+  developing. Do not ship `'*'` together with credentials support.
+- `allowedMethods` needs more than GET only if the site writes through
+  JSON:API (forms). `OPTIONS` must stay: browsers send it as the
+  preflight.
+- `supportsCredentials` stays `false` for anonymous reads. Set it `true`
+  only for cookie-based authenticated flows, in which case
+  `allowedOrigins` must list explicit origins, never `'*'`.
+
+## Verify
+
+Ask Drupal for a resource with an `Origin` header and check the response:
+
+```sh
+curl -sI -H "Origin: https://www.example.com" \
+  https://cms.example.com/jsonapi | grep -i access-control
+```
+
+A working configuration answers with
+`access-control-allow-origin: https://www.example.com`. No
+`access-control-*` headers at all means the block is not loading: confirm
+the file is `sites/default/services.yml`, the site was cache-rebuilt, and
+your hosting platform does not strip the headers.
+
+## Per-environment configuration
+
+Origins differ per environment, and `services.yml` is not part of config
+sync. A clean pattern used by production Druxt sites: keep a
+`services.yml` per environment (for example
+`sites/default/envs/<env>/services.yml`) and include the right one from
+`settings.php`, so development can stay permissive while production lists
+exact origins.
+
+## When to prefer the proxy
+
+| Situation | Use |
+| --------- | --- |
+| Generated static site (`nuxt generate`) | CORS. There is no server to proxy through. |
+| Nuxt server, one frontend origin | Either. The [proxy](/how-to/proxy) needs no backend change. |
+| Several frontends sharing one backend | CORS, with each origin listed. |
+| You cannot change the backend | The proxy, and a server-rendered deployment. |

--- a/docs/nuxt/content/how-to/configure-cors.md
+++ b/docs/nuxt/content/how-to/configure-cors.md
@@ -57,8 +57,12 @@ Three keys matter most:
   JSON:API (forms). `OPTIONS` must stay: browsers send it as the
   preflight.
 - `supportsCredentials` stays `false` for anonymous reads. Set it `true`
-  only for cookie-based authenticated flows, in which case
-  `allowedOrigins` must list explicit origins, never `'*'`.
+  only for credentialed flows, in which case `allowedOrigins` must list
+  explicit origins, never `'*'`, and `allowedHeaders` must name the
+  headers your requests use, such as
+  `['Authorization', 'Content-Type', 'Accept']`: the wildcard does not
+  cover non-safelisted headers on credentialed requests, and
+  `Authorization` always needs an explicit entry.
 
 ## Verify
 
@@ -66,6 +70,19 @@ Ask Drupal for a resource with an `Origin` header and check the response:
 
 ```sh
 curl -sI -H "Origin: https://www.example.com" \
+  https://cms.example.com/jsonapi | grep -i access-control
+```
+
+That covers simple reads. Requests with non-simple methods or headers
+(writes, `Authorization`) go through an `OPTIONS` preflight, so test
+that too, and check the allow-origin, allow-methods and allow-headers
+values that come back:
+
+```sh
+curl -si -X OPTIONS \
+  -H "Origin: https://www.example.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: authorization,content-type" \
   https://cms.example.com/jsonapi | grep -i access-control
 ```
 

--- a/docs/nuxt/content/how-to/configure-cors.md
+++ b/docs/nuxt/content/how-to/configure-cors.md
@@ -13,18 +13,19 @@ When the frontend and backend are on different origins, the browser blocks
 cross-origin JSON:API requests unless Drupal answers with CORS headers.
 This is the direct fix. The alternative, [proxying through the
 frontend](/how-to/proxy), avoids CORS but only works while a Nuxt server
-is running; a generated static site needs CORS.
+is running. A generated static site needs CORS.
 
-The Druxt Drupal module enables CORS by default when it is otherwise
-disabled, which is enough for anonymous reads. It does not set the
-allowed methods, so preflighted requests (form submissions, and any
-request carrying an `Authorization` header) can still fail until you
-configure the block below explicitly. Explicit configuration always
-wins, and is what production sites should ship.
+The Druxt Drupal module enables CORS when it is otherwise disabled,
+which covers anonymous reads because Drupal core's stock configuration
+allows every origin. The module does not set the allowed methods, so
+preflighted requests (form submissions, and any request carrying an
+`Authorization` header) can still fail until you configure the block
+below explicitly. Explicit configuration always wins, and is what
+production sites should run.
 
 ## Enable cors.config
 
-Drupal core ships the configuration disabled in
+Drupal core includes the configuration, disabled, in
 `sites/default/default.services.yml`. Copy the file to
 `sites/default/services.yml` if it does not exist, and set the
 `cors.config` block:
@@ -47,12 +48,13 @@ Then rebuild caches:
 drush cache:rebuild
 ```
 
-Three keys matter most:
+The keys to get right:
 
 - `allowedOrigins` is your frontend origin, scheme included, no trailing
   slash. List each environment that needs access (production, previews,
-  `http://localhost:3000` for local development), or use `['*']` while
-  developing. Do not ship `'*'` together with credentials support.
+  `http://localhost:3000`, the Nuxt dev server's default, for local
+  development), or use `['*']` while
+  developing. Never deploy `'*'` together with credentials support.
 - `allowedMethods` needs more than GET only if the site writes through
   JSON:API (forms). `OPTIONS` must stay: browsers send it as the
   preflight.
@@ -66,7 +68,8 @@ Three keys matter most:
 
 ## Verify
 
-Ask Drupal for a resource with an `Origin` header and check the response:
+Ask Drupal for a resource with an `Origin` header, and check the
+response:
 
 ```sh
 curl -sI -H "Origin: https://www.example.com" \
@@ -96,16 +99,16 @@ your hosting platform does not strip the headers.
 
 Origins differ per environment, and `services.yml` is not part of config
 sync. A clean pattern used by production Druxt sites: keep a
-`services.yml` per environment (for example
+`services.yml` per environment (say
 `sites/default/envs/<env>/services.yml`) and include the right one from
 `settings.php`, so development can stay permissive while production lists
 exact origins.
 
 ## When to prefer the proxy
 
-| Situation | Use |
-| --------- | --- |
-| Generated static site (`nuxt generate`) | CORS. There is no server to proxy through. |
-| Nuxt server, one frontend origin | Either. The [proxy](/how-to/proxy) needs no backend change. |
-| Several frontends sharing one backend | CORS, with each origin listed. |
-| You cannot change the backend | The proxy, and a server-rendered deployment. |
+| Situation                               | Use                                                              |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| Generated static site (`nuxt generate`) | CORS. The proxy would need a server.                             |
+| Nuxt server, one frontend origin        | Either. The [proxy](/how-to/proxy) leaves the backend untouched. |
+| Several frontends sharing one backend   | CORS, with each origin listed.                                   |
+| You cannot change the backend           | The proxy, and a server-rendered deployment.                     |

--- a/docs/nuxt/content/how-to/configure-cors.md
+++ b/docs/nuxt/content/how-to/configure-cors.md
@@ -72,7 +72,7 @@ Ask Drupal for a resource with an `Origin` header, and check the
 response:
 
 ```sh
-curl -sI -H "Origin: https://www.example.com" \
+curl -s -o /dev/null -D - -H "Origin: https://www.example.com" \
   https://cms.example.com/jsonapi | grep -i access-control
 ```
 

--- a/docs/nuxt/content/how-to/prepare-the-backend.md
+++ b/docs/nuxt/content/how-to/prepare-the-backend.md
@@ -1,0 +1,113 @@
+---
+title: Prepare the Drupal backend
+weight: -8
+description: 'Make an existing Drupal site Druxt-ready: modules, JSON:API settings, permissions and the minimum content the frontend needs.'
+---
+
+The [quickstart](/tutorials/getting-started) provisions a ready-made
+backend. This guide is for the other case: pointing Druxt at a Drupal site
+you already have, or building the backend by hand.
+
+## Install the Druxt module
+
+```sh
+composer require drupal/druxt
+drush pm:enable druxt
+```
+
+The module depends on core's `jsonapi` module and three contrib projects:
+[Decoupled Router](https://www.drupal.org/project/decoupled_router),
+[JSON:API Menu Items](https://www.drupal.org/project/jsonapi_menu_items)
+and [JSON:API Views](https://www.drupal.org/project/jsonapi_views).
+Composer downloads them with the module, and enabling `druxt` enables all
+of them. Drupal core `8.8` through `11` is supported.
+
+If composer refuses with a stability error, your project's
+`minimum-stability` is stricter than a dependency's current release.
+Require the module with an explicit constraint first, for example
+`composer require drupal/druxt:^1.0`, and only lower `minimum-stability`
+as a last resort.
+
+## Grant the permission
+
+Grant **Access DruxtJS JSON:API resources** (`access druxt resources`) to
+every role the frontend connects as. For a public site that is the
+**Anonymous** role:
+
+```sh
+drush role:perm:add anonymous 'access druxt resources'
+```
+
+The permission grants read-only (GET) access to the configuration
+resources the frontend needs to build itself: entity view and form
+displays, field configuration, menus, menu links and views. Without it,
+every one of those requests returns 403, and the errors name the
+underlying resource rather than the permission, which makes the cause hard
+to spot. See
+[Troubleshooting](/how-to/troubleshooting#every-jsonapi-request-403s-even-for-content-that-should-be-public).
+
+It grants nothing else: content entities keep their normal Drupal access
+rules. Granting it to Anonymous exposes structure (display and field
+configuration), not content that Drupal would otherwise protect. If that
+trade-off is not acceptable, connect as an authenticated consumer instead
+and see the topology notes on
+[cookies and sessions](/explanation/request-topology#cookies-and-sessions).
+
+## Check the JSON:API settings
+
+Core's JSON:API defaults to read-only mode. Reads are all Druxt needs to
+render a site, but form submissions through `DruxtEntityForm` are JSON:API
+writes and will fail with 405 responses until writes are enabled:
+
+```sh
+drush config:set jsonapi.settings read_only 0
+```
+
+Leave `read_only` enabled if the site never writes through the API.
+
+## Have some content and displays
+
+The frontend builds its [schemas](/explanation/schemas) from entity view
+and form displays at build time. A site with no content types produces no
+schemas, and the build fails with a misleading `./schemas not found`
+error. At minimum, create one content type before the first frontend
+build. The Druxt module creates missing view displays for new bundles
+automatically.
+
+Display changes made after the frontend starts need a rebuild or dev
+server restart to appear. See
+[Troubleshooting](/how-to/troubleshooting#i-changed-a-drupal-display-and-nothing-happened-on-the-frontend).
+
+## Commonly added modules
+
+Not required, but production Druxt sites regularly add these:
+
+| Module | Why |
+| ------ | --- |
+| [JSON:API Extras](https://www.drupal.org/project/jsonapi_extras) | Rename or re-prefix the API path (pair with Druxt's `endpoint` option, e.g. `endpoint: '/api'`), disable unused resources. |
+| [JSON:API Image Styles](https://www.drupal.org/project/jsonapi_image_styles) | Expose image style URLs so the frontend can use derivatives instead of original files. |
+| [Redirect](https://www.drupal.org/project/redirect) | Legacy URL redirects, resolved through the decoupled router. |
+| [Simple XML sitemap](https://www.drupal.org/project/simple_sitemap) | Generate the sitemap on the backend; serve or proxy it from the frontend. |
+| [m4032404](https://www.drupal.org/project/m4032404) and [r4032login](https://www.drupal.org/project/r4032login) | Sane 403/404 semantics for decoupled route resolution. |
+
+Decoupled Router's `absolute_resolved_urls` setting is worth enabling so
+resolved routes carry absolute URLs.
+
+## Cross-origin access
+
+If the frontend and backend are served from different origins, decide
+between configuring CORS in Drupal and proxying browser requests through
+the frontend before you deploy. [Request
+topology](/explanation/request-topology) explains the difference;
+[Configure CORS](/how-to/configure-cors) and
+[Proxy the backend](/how-to/proxy) are the two implementations.
+
+## Checklist
+
+| Item | Command or place |
+| ---- | ---------------- |
+| Druxt module installed and enabled | `composer require drupal/druxt` + `drush pm:enable druxt` |
+| Permission granted to the connecting role | `drush role:perm:add anonymous 'access druxt resources'` |
+| JSON:API writes, if forms are used | `drush config:set jsonapi.settings read_only 0` |
+| At least one content type with a display | Drupal admin |
+| CORS or proxy decided | [Request topology](/explanation/request-topology) |

--- a/docs/nuxt/content/how-to/prepare-the-backend.md
+++ b/docs/nuxt/content/how-to/prepare-the-backend.md
@@ -5,14 +5,22 @@ description: 'Make an existing Drupal site Druxt-ready: modules, JSON:API settin
 ---
 
 The [quickstart](/tutorials/getting-started) provisions a ready-made
-backend. This guide is for the other case: pointing Druxt at a Drupal site
-you already have, or building the backend by hand.
+backend. This guide is for the other case: making a Drupal site you
+already have Druxt-ready. (Starting from nothing? Create a site with
+[Drupal's own instructions](https://www.drupal.org/docs/getting-started)
+first, then return here.)
+
+Commands run in the Drupal project root. `composer` manages Drupal
+dependencies; [drush](https://www.drush.org) is Drupal's CLI, installed
+into the project with `composer require drush/drush`. If the backend
+runs in a container, prefix commands with your tool's exec command.
+Every step also has an admin-UI path, noted as it appears.
 
 ## Install the Druxt module
 
 ```sh
 composer require drupal/druxt
-drush pm:enable druxt
+drush pm:enable druxt -y
 ```
 
 The module depends on core's `jsonapi` module and three contrib projects:
@@ -20,18 +28,29 @@ The module depends on core's `jsonapi` module and three contrib projects:
 [JSON:API Menu Items](https://www.drupal.org/project/jsonapi_menu_items)
 and [JSON:API Views](https://www.drupal.org/project/jsonapi_views).
 Composer downloads them with the module, and enabling `druxt` enables all
-of them. Drupal core `8.8` through `11` is supported.
+of them. In practice this needs Drupal core `10.1` or later (the module
+itself accepts `8.8`+, but its Decoupled Router 2.x dependency requires
+`10.1`), and the maintained backends test against 10 and 11.
 
-If composer refuses with a stability error, your project's
-`minimum-stability` is stricter than a dependency's current release.
-Require the module with an explicit constraint first, for example
-`composer require drupal/druxt:^1.0`, and only lower `minimum-stability`
-as a last resort.
+Keep Decoupled Router below `2.0.7` for now
+(`composer require 'drupal/decoupled_router:^2.0 <2.0.7'`). 2.0.7
+changed a subscriber signature the current Druxt module does not
+declare, and route resolution silently stops working
+([#3618675](https://www.drupal.org/i/3618675)).
+
+If composer refuses with a stability error, a dependency's current
+release is below your project's `minimum-stability` (set in the Drupal
+project's `composer.json`). Allow the pre-release for that one package
+with a stability flag, as in
+`composer require drupal/jsonapi_views:^1.1@beta`, rather than lowering
+`minimum-stability` project-wide.
 
 ## Grant the permission
 
-Grant **Access DruxtJS JSON:API resources** (`access druxt resources`) to
-every role the frontend connects as. For a public site that is the
+Drupal has two built-in roles, Anonymous and Authenticated, and
+permissions attach to roles. Grant **Access DruxtJS JSON:API resources**
+(`access druxt resources`) to every role the frontend connects as, at
+`/admin/people/permissions` or with drush. For a public site that is the
 **Anonymous** role:
 
 ```sh
@@ -40,11 +59,13 @@ drush role:perm:add anonymous 'access druxt resources'
 
 The permission grants read-only (GET) access to the configuration
 resources the frontend needs to build itself: entity view and form
-displays, field configuration, menus, menu links and views. Without it,
+displays and modes, field and field storage configuration, JSON:API
+resource configuration, blocks, languages, menus, menu links and views.
+Without it,
 every one of those requests returns 403, and the errors name the
 underlying resource rather than the permission, which makes the cause hard
 to spot. See
-[Troubleshooting](/how-to/troubleshooting#every-jsonapi-request-403s-even-for-content-that-should-be-public).
+[the 403 entry in Troubleshooting](/how-to/troubleshooting#every-jsonapi-request-403s-even-for-content-that-should-be-public).
 
 It grants nothing else: content entities keep their normal Drupal access
 rules. Granting it to Anonymous exposes structure (display and field
@@ -56,42 +77,47 @@ and see the topology notes on
 ## Check the JSON:API settings
 
 Core's JSON:API defaults to read-only mode. Reads are all Druxt needs to
-render a site, but form submissions through `DruxtEntityForm` are JSON:API
-writes and will fail with 405 responses until writes are enabled:
+render a site, but form submissions through
+[DruxtEntityForm](/modules/entity) are JSON:API writes and will fail
+with 405 responses until writes are enabled, at
+`/admin/config/services/jsonapi` or with drush:
 
 ```sh
-drush config:set jsonapi.settings read_only 0
+drush config:set jsonapi.settings read_only 0 -y
 ```
 
-Leave `read_only` enabled if the site never writes through the API.
+Skip this if the site never writes through the API; read-only is the
+safer place to stay.
 
 ## Have some content and displays
 
-The frontend builds its [schemas](/explanation/schemas) from entity view
-and form displays at build time. A site with no content types produces no
-schemas, and the build fails with a misleading `./schemas not found`
-error. At minimum, create one content type before the first frontend
-build. The Druxt module creates missing view displays for new bundles
+When the frontend builds (its [build-time
+context](/explanation/request-topology)), it derives
+[schemas](/explanation/schemas) from entity view and form displays. A
+site with no content types cannot produce any schemas, and the build stops
+with `No Druxt Schema files generated. Have you created any content
+types yet?`. At minimum, create one content type before the first
+frontend build. The Druxt module creates missing view displays for new bundles
 automatically.
 
 Display changes made after the frontend starts need a rebuild or dev
 server restart to appear. See
-[Troubleshooting](/how-to/troubleshooting#i-changed-a-drupal-display-and-nothing-happened-on-the-frontend).
+[the display-change entry in Troubleshooting](/how-to/troubleshooting#i-changed-a-drupal-display-and-nothing-happened-on-the-frontend).
 
 ## Commonly added modules
 
 Not required, but production Druxt sites regularly add these:
 
-| Module | Why |
-| ------ | --- |
-| [JSON:API Extras](https://www.drupal.org/project/jsonapi_extras) | Rename or re-prefix the API path (pair with Druxt's `endpoint` option, e.g. `endpoint: '/api'`), disable unused resources. |
-| [JSON:API Image Styles](https://www.drupal.org/project/jsonapi_image_styles) | Expose image style URLs so the frontend can use derivatives instead of original files. |
-| [Redirect](https://www.drupal.org/project/redirect) | Legacy URL redirects, resolved through the decoupled router. |
-| [Simple XML sitemap](https://www.drupal.org/project/simple_sitemap) | Generate the sitemap on the backend; serve or proxy it from the frontend. |
-| [m4032404](https://www.drupal.org/project/m4032404) and [r4032login](https://www.drupal.org/project/r4032login) | Sane 403/404 semantics for decoupled route resolution. |
+| Module                                                                                                                                                        | Why                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [JSON:API Extras](https://www.drupal.org/project/jsonapi_extras)                                                                                              | Rename or re-prefix the API path (pair with Druxt's `endpoint` option, e.g. `endpoint: '/api'`), disable unused resources. |
+| [JSON:API Image Styles](https://www.drupal.org/project/jsonapi_image_styles)                                                                                  | Expose image style URLs so the frontend can use derivatives instead of original files.                                     |
+| [Redirect](https://www.drupal.org/project/redirect)                                                                                                           | Legacy URL redirects, resolved through the decoupled router.                                                               |
+| [Simple XML sitemap](https://www.drupal.org/project/simple_sitemap)                                                                                           | Generate the sitemap on the backend and serve or proxy it from the frontend.                                               |
+| [m4032404, a 403-to-404 mapper](https://www.drupal.org/project/m4032404) and [r4032login, a 403-to-login redirect](https://www.drupal.org/project/r4032login) | Sane 403/404 semantics for decoupled route resolution.                                                                     |
 
-Decoupled Router's `absolute_resolved_urls` setting is worth enabling so
-resolved routes carry absolute URLs.
+Decoupled Router installs with `absolute_resolved_urls` enabled, so
+resolved routes come back as absolute URLs. Leave it on.
 
 ## Cross-origin access
 
@@ -104,10 +130,10 @@ topology](/explanation/request-topology) explains the difference;
 
 ## Checklist
 
-| Item | Command or place |
-| ---- | ---------------- |
-| Druxt module installed and enabled | `composer require drupal/druxt` + `drush pm:enable druxt` |
-| Permission granted to the connecting role | `drush role:perm:add anonymous 'access druxt resources'` |
-| JSON:API writes, if forms are used | `drush config:set jsonapi.settings read_only 0` |
-| At least one content type with a display | Drupal admin |
-| CORS or proxy decided | [Request topology](/explanation/request-topology) |
+| Item                                      | Command or place                                          |
+| ----------------------------------------- | --------------------------------------------------------- |
+| Druxt module installed and enabled        | `composer require drupal/druxt` + `drush pm:enable druxt` |
+| Permission granted to the connecting role | `drush role:perm:add anonymous 'access druxt resources'`  |
+| JSON:API writes, if forms are used        | `drush config:set jsonapi.settings read_only 0`           |
+| At least one content type with a display  | Drupal admin                                              |
+| CORS or proxy decided                     | [Request topology](/explanation/request-topology)         |

--- a/docs/nuxt/content/how-to/proxy.md
+++ b/docs/nuxt/content/how-to/proxy.md
@@ -7,7 +7,14 @@ description: Prevent CORS issues by routing API and file requests through the fr
 Druxt provides API and File proxying using the @nuxtjs/proxy module.
 
 > **Before you start:** this guide assumes a working Druxt site. See
-> [Getting started](/tutorials/getting-started).
+> [Getting started](/tutorials/getting-started). To understand when the
+> proxy applies and when you need [CORS](/how-to/configure-cors) instead,
+> see [Request topology](/explanation/request-topology).
+
+The proxy is server middleware: it runs inside `nuxt dev` and
+`nuxt start`. **A generated static site has no server, so the proxy does
+not exist there.** If you deploy with `nuxt generate` and the browser must
+reach Drupal, [configure CORS in Drupal](/how-to/configure-cors) instead.
 
 ---
 

--- a/docs/nuxt/content/how-to/proxy.md
+++ b/docs/nuxt/content/how-to/proxy.md
@@ -11,9 +11,9 @@ Druxt provides API and File proxying using the @nuxtjs/proxy module.
 > proxy applies and when you need [CORS](/how-to/configure-cors) instead,
 > see [Request topology](/explanation/request-topology).
 
-The proxy is server middleware: it runs inside `nuxt dev` and
-`nuxt start`. **A generated static site has no server, so the proxy does
-not exist there.** If you deploy with `nuxt generate` and the browser must
+The proxy runs as server middleware inside `nuxt dev` and `nuxt start`.
+**A generated static site has no server, so the proxy does not exist
+there.** If you deploy with `nuxt generate` and the browser must
 reach Drupal, [configure CORS in Drupal](/how-to/configure-cors) instead.
 
 ---

--- a/docs/nuxt/content/how-to/troubleshooting.md
+++ b/docs/nuxt/content/how-to/troubleshooting.md
@@ -95,8 +95,9 @@ backend](/how-to/prepare-the-backend).
 
 ## "require() of ES Module axios" crash on a fresh install
 
-Newer axios releases are ESM-only and break Nuxt 2's CommonJS server
-build. Pin axios to a 0.x release, or transpile it:
+Nuxt 2's webpack 4 resolves newer axios releases through their ESM
+entry, which its CommonJS server build cannot load. Pin axios to a 0.x
+release, or transpile it:
 
 ```js
 export default {
@@ -108,8 +109,9 @@ export default {
 
 ## "error:0308010C:digital envelope routines" on Node 17 or later
 
-Nuxt 2's webpack 4 uses an OpenSSL API that Node 17 removed. Either build
-on Node 16, or set the legacy provider in the build environment:
+Node 17 moved to OpenSSL 3, which rejects the legacy hashing algorithms
+Nuxt 2's webpack 4 relies on. Either build on Node 16, or enable the
+legacy provider in the build environment:
 
 ```sh
 NODE_OPTIONS=--openssl-legacy-provider nuxt build

--- a/docs/nuxt/content/how-to/troubleshooting.md
+++ b/docs/nuxt/content/how-to/troubleshooting.md
@@ -8,10 +8,8 @@ description: Quick answers to the problems reported most often by real users, fr
 > [Getting started](/tutorials/getting-started).
 
 This page covers the issues that account for most of the confusion
-reported by real users over the life of this project. Each entry below is a
-quick answer with a link to the fuller explanation.
-
----
+reported by real users over the life of this project. Each entry is a
+quick answer, with a link wherever a fuller explanation exists.
 
 ## "Missing Vue template" box
 
@@ -52,8 +50,8 @@ full installation steps.
 ## "…has been blocked by CORS policy" in the browser console
 
 The browser is refusing a cross-origin request to Drupal. Only requests
-made **by the browser** can fail this way; if the site server-renders fine
-and breaks on navigation or dynamic data, this is why. Two fixes, pick
+made **by the browser** can fail this way, so a site that server-renders
+fine and breaks on navigation or live data is failing here. Two fixes, pick
 one: [configure CORS in Drupal](/how-to/configure-cors) so the backend
 answers cross-origin requests, or [proxy the API through the
 frontend](/how-to/proxy) so no request is cross-origin (server deployments
@@ -81,23 +79,24 @@ and the homepage resolves through Drupal like every other path. See
 
 ## Build error: the pages directory is missing
 
-Nuxt requires a `pages/` directory even when Druxt's wildcard router
-provides every route. Create it with a placeholder:
-`mkdir pages && touch pages/.gitkeep`.
+Nuxt requires a `pages/` directory even when [Druxt's wildcard
+router](/explanation/routing) provides every route. Create it with a
+placeholder: `mkdir pages && touch pages/.gitkeep`.
 
 ## Composer refuses to install drupal/druxt
 
 A stability error (`minimum-stability`) means a dependency's current
-release is below your project's floor. Require an explicit constraint,
-for example `composer require drupal/druxt:^1.0`, before loosening
-`minimum-stability`. See [Prepare the Drupal
+release is below your project's floor. Allow the pre-release for that
+one package with a stability flag, as in
+`composer require drupal/jsonapi_views:^1.1@beta`, rather than lowering
+`minimum-stability` project-wide. See [Prepare the Drupal
 backend](/how-to/prepare-the-backend).
 
 ## "require() of ES Module axios" crash on a fresh install
 
 Nuxt 2's webpack 4 resolves newer axios releases through their ESM
-entry, which its CommonJS server build cannot load. Pin axios to a 0.x
-release, or transpile it:
+entry, which the server, built as CommonJS, cannot load. Pin axios to a 0.x
+release, or transpile it in `nuxt.config.js`:
 
 ```js
 export default {
@@ -118,17 +117,23 @@ NODE_OPTIONS=--openssl-legacy-provider nuxt build
 ```
 
 This also works in CI and static-host build settings by prefixing the
-build command.
+build command. Pin the build host's Node version explicitly so this
+stays predictable.
 
 ## Builds fail on Windows
 
 Nuxt 2 tooling and several Druxt build steps have known problems on
 native Windows (path separators, OpenSSL differences). Use
 [WSL2](https://learn.microsoft.com/windows/wsl/) and run everything
-inside the Linux environment; that is the tested and recommended setup.
+inside the Linux environment. That is the setup the maintainers test.
 
 ## Where to go next
 
 - [Theme Druxt components](/how-to/theming): wrapper components in full.
 - [The schema system](/explanation/schemas): how schemas are built and cached.
+- [Request topology](/explanation/request-topology): which request is
+  actually failing, and why.
+- [Prepare the Drupal backend](/how-to/prepare-the-backend) and
+  [Configure CORS in Drupal](/how-to/configure-cors): the backend-side
+  fixes.
 - [`druxt` module reference](/modules/druxt): installation and permissions.

--- a/docs/nuxt/content/how-to/troubleshooting.md
+++ b/docs/nuxt/content/how-to/troubleshooting.md
@@ -7,7 +7,7 @@ description: Quick answers to the problems reported most often by real users, fr
 > **Before you start:** this guide assumes a working Druxt site. See
 > [Getting started](/tutorials/getting-started).
 
-This page covers the three issues that account for most of the confusion
+This page covers the issues that account for most of the confusion
 reported by real users over the life of this project. Each entry below is a
 quick answer with a link to the fuller explanation.
 
@@ -48,6 +48,82 @@ before debugging anything else. The [quickstart](/tutorials/getting-started)
 grants this automatically. Installing Druxt on an existing site does not.
 See the [`druxt` module reference](/modules/druxt#installation) for the
 full installation steps.
+
+## "…has been blocked by CORS policy" in the browser console
+
+The browser is refusing a cross-origin request to Drupal. Only requests
+made **by the browser** can fail this way; if the site server-renders fine
+and breaks on navigation or dynamic data, this is why. Two fixes, pick
+one: [configure CORS in Drupal](/how-to/configure-cors) so the backend
+answers cross-origin requests, or [proxy the API through the
+frontend](/how-to/proxy) so no request is cross-origin (server deployments
+only). [Request topology](/explanation/request-topology) explains when
+each applies.
+
+## The build fails reaching the backend (ECONNREFUSED, timeouts, 400s)
+
+`nuxt build` and `nuxt generate` fetch schemas and content from Drupal
+**from the machine running the build**. A `baseUrl` that works in your
+browser can still be unreachable from the build: `localhost` inside a
+container is the container itself, a Docker hostname does not resolve
+outside its network, and a backend behind basic auth or a VPN blocks the
+build the same way. Confirm with `curl <baseUrl>/jsonapi` from the build
+environment. CI setups should wait for the backend to answer before
+starting the build. See [Request
+topology](/explanation/request-topology#baseurl-rules).
+
+## The site only shows "Welcome to Nuxt"
+
+The Nuxt scaffolder creates a default `pages/index.vue`, and an explicit
+page always wins over Druxt's wildcard route. Delete `pages/index.vue`
+and the homepage resolves through Drupal like every other path. See
+[Decoupled routing](/explanation/routing).
+
+## Build error: the pages directory is missing
+
+Nuxt requires a `pages/` directory even when Druxt's wildcard router
+provides every route. Create it with a placeholder:
+`mkdir pages && touch pages/.gitkeep`.
+
+## Composer refuses to install drupal/druxt
+
+A stability error (`minimum-stability`) means a dependency's current
+release is below your project's floor. Require an explicit constraint,
+for example `composer require drupal/druxt:^1.0`, before loosening
+`minimum-stability`. See [Prepare the Drupal
+backend](/how-to/prepare-the-backend).
+
+## "require() of ES Module axios" crash on a fresh install
+
+Newer axios releases are ESM-only and break Nuxt 2's CommonJS server
+build. Pin axios to a 0.x release, or transpile it:
+
+```js
+export default {
+  build: {
+    transpile: ['axios'],
+  },
+};
+```
+
+## "error:0308010C:digital envelope routines" on Node 17 or later
+
+Nuxt 2's webpack 4 uses an OpenSSL API that Node 17 removed. Either build
+on Node 16, or set the legacy provider in the build environment:
+
+```sh
+NODE_OPTIONS=--openssl-legacy-provider nuxt build
+```
+
+This also works in CI and static-host build settings by prefixing the
+build command.
+
+## Builds fail on Windows
+
+Nuxt 2 tooling and several Druxt build steps have known problems on
+native Windows (path separators, OpenSSL differences). Use
+[WSL2](https://learn.microsoft.com/windows/wsl/) and run everything
+inside the Linux environment; that is the tested and recommended setup.
 
 ## Where to go next
 


### PR DESCRIPTION
First of four stacked documentation PRs (each based on the previous; feature/docs-content-base carries the Diataxis content they build on). This one adds the backend and topology layer:

- explanation/request-topology: which requests happen at build time, during server rendering and in the browser, when CORS applies versus the API proxy, hosting layouts, and the baseUrl rules. Written to answer the most common support cluster in the project's history.
- how-to/prepare-the-backend: making an existing Drupal site Druxt-ready. Module install with the real version bounds, the access druxt resources grant and what it actually opens, JSON:API read-only versus writes, and the minimum content the first build needs.
- how-to/configure-cors: the services.yml block, per-environment configuration, and curl verification, plus the limits of the module's out-of-the-box CORS enabling.
- how-to/troubleshooting grows from three entries to eleven, each phrased as the symptom readers report.
- how-to/proxy now states that the proxy is server middleware and does not exist in generated static output.

Every internal link is enforced by the site's route guard at generate time; facts are verified against the module and framework source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on Druxt request topology, including build-time, server-side, and browser requests.
  - Added instructions for preparing Drupal backends and configuring CORS.
  - Clarified proxy behavior for development, server deployments, and static sites.
  - Updated architecture documentation with backend module and dependency details.
  - Expanded troubleshooting guidance for connectivity, CORS, builds, configuration, and platform-specific issues.
  - Added links to the new documentation from the relevant indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->