### PR TITLE
docs: deployment models, static deploy guide, deploy tutorial and env reference

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -111,6 +111,7 @@ nuxi
 nuxt
 nuxtjs
 octref
+olivero
 opcache
 openspec
 pbody
@@ -121,6 +122,7 @@ phpstan
 PKCE
 pkill
 prebuilds
+preconfigure
 preconfigured
 preflighted
 Quickstart
@@ -137,6 +139,7 @@ router
 safelisted
 satori
 scaffolder
+scriptable
 scule
 Segoe
 segoe
@@ -159,6 +162,7 @@ toggleable
 topbar
 trixie
 umami
+uncacheable
 unjs
 unlighthouse
 unregisters

--- a/docs/nuxt/content/explanation/README.md
+++ b/docs/nuxt/content/explanation/README.md
@@ -23,3 +23,5 @@ instructions. For doing, see the [How-to guides](/how-to).
   discovery and the theme layer.
 - [Request topology](/explanation/request-topology): build, server and
   browser requests, and what that means for CORS, the proxy and hosting.
+- [Deployment models](/explanation/deployment-models): fully static,
+  static with a live backend, or server-rendered, and how to choose.

--- a/docs/nuxt/content/explanation/deployment-models.md
+++ b/docs/nuxt/content/explanation/deployment-models.md
@@ -1,0 +1,93 @@
+---
+title: Deployment models
+weight: -3
+description: How a Druxt site goes to production, from fully static files through a server-rendered node service, and how to choose between the models.
+---
+
+Druxt is a layer on top of Nuxt and Drupal, and it deploys the way Nuxt
+deploys: as generated static files, or as a node server. `nuxt generate`
+renders every page to files at build time; `nuxt build` compiles an app
+that a node server renders per request. The choice decides where you can
+host, what it costs, and which features work. [Request
+topology](/explanation/request-topology) explains the request mechanics
+behind this page.
+
+## The models
+
+|                      | Fully static           | Static + live backend                | Server-rendered |
+| -------------------- | ---------------------- | ------------------------------------ | --------------- |
+| Build command        | `nuxt generate`        | `nuxt generate`                      | `nuxt build`    |
+| Frontend hosting     | Any static host or CDN | Any static host or CDN               | A node server   |
+| Drupal in production | Not required           | Required                             | Required        |
+| Content updates      | Rebuild                | Rebuild for pages, live for the rest | Live            |
+| Forms, auth, search  | No                     | Yes                                  | Yes             |
+| API proxy            | No (no server)         | No (no server)                       | Yes             |
+
+**Fully static** generates every page at build time and deploys plain
+files, with no backend left running. This is a deliberate build mode, not the
+default: an ordinary build still asks Drupal to resolve routes when a
+visitor navigates, so going backendless means disabling the router
+middleware (`druxt.router.middleware: false` in `nuxt.config.js`) and
+cutting out every runtime request. A databaseless backend completes the
+shape: Drupal exists only during the build, its content exported to
+files with [Tome](https://tome.fyi), as in the
+[quickstart-druxt-site-tome](https://github.com/druxt/quickstart-druxt-site-tome)
+starter. The starter does not yet preconfigure the no-runtime-requests
+half, so treat that part as an advanced configuration.
+
+**Static + live backend** is the recommended default. Pages are generated
+and served from a static host, while the browser talks to the
+still-running Drupal for the live parts: authenticated content, form
+submissions, search. With no frontend server to proxy through, this
+model needs [CORS configured in Drupal](/how-to/configure-cors).
+
+**Server-rendered** runs the built app as a node service: a long-lived
+process you supervise, listening on a port behind your web server. Every
+request renders live data, the [API proxy](/how-to/proxy) can shield the
+backend origin, and server middleware can hold secrets (mail delivery,
+search backends). You host and operate that node process alongside PHP.
+
+Production sites also combine models into a hybrid: static files with a
+server fallback. One build serves generated pages from a web server with
+long cache headers, and a node service behind it catches routes that
+were not generated, such as authenticated pages. Nuxt's `target` option
+(the build target) can be driven by an environment variable so one
+`nuxt.config.js` serves all modes. A server deployment guide showing
+the working shape arrives with the authentication material.
+
+## Choosing a model
+
+- Content site, editors publish on a schedule: **static + live backend**,
+  with scheduled rebuilds.
+- Brochure site, content rarely changes: **fully static**, backend off or
+  databaseless.
+- Logged-in experiences, per-user pages, secrets in server code:
+  **server-rendered**, or the hybrid above.
+
+## Serving Druxt from Drupal
+
+A question that comes up regularly: can Druxt run progressively
+decoupled, served by Drupal itself?
+
+What works today is the **same-origin layout**: generate the site and let
+the web server in front of Drupal serve the files, routing `/jsonapi` and
+`/router` to Drupal. One origin, no CORS, and Drupal cookies work
+everywhere. The frontend is still a whole application owning the page.
+
+What Druxt does not do today is true progressive decoupling: rendering
+individual Druxt components inside Drupal-rendered (Twig) pages. The
+components need the running Nuxt application around them (its store and
+plugin system), which a Twig page does not have. The tracked feature
+request is a custom-elements build: web components a Drupal theme could
+attach as a library and place straight into markup. The
+[DruxtClient](/how-to/use-the-druxt-client) already runs outside Nuxt,
+so the data half of that is ready.
+
+## Where to go next
+
+- [Deploy a static site](/how-to/deploy-static): the generate-and-host
+  procedure.
+- [Environment variables](/how-to/environment-variables): what each
+  build needs to know.
+- [The deploy-your-site tutorial](/tutorials/deploy-your-site): this
+  page's decision, walked end to end from the quickstart.

--- a/docs/nuxt/content/explanation/deployment-models.md
+++ b/docs/nuxt/content/explanation/deployment-models.md
@@ -30,7 +30,8 @@ visitor navigates, so going backendless means disabling the router
 middleware (`druxt.router.middleware: false` in `nuxt.config.js`) and
 cutting out every runtime request. A databaseless backend completes the
 shape: Drupal exists only during the build, its content exported to
-files with [Tome](https://tome.fyi), as in the
+files with [Tome](https://www.drupal.org/project/tome)'s Tome Sync, as
+in the
 [quickstart-druxt-site-tome](https://github.com/druxt/quickstart-druxt-site-tome)
 starter. The starter does not yet preconfigure the no-runtime-requests
 half, so treat that part as an advanced configuration.
@@ -52,8 +53,7 @@ server fallback. One build serves generated pages from a web server with
 long cache headers, and a node service behind it catches routes that
 were not generated, such as authenticated pages. Nuxt's `target` option
 (the build target) can be driven by an environment variable so one
-`nuxt.config.js` serves all modes. A server deployment guide showing
-the working shape arrives with the authentication material.
+`nuxt.config.js` serves all modes.
 
 ## Choosing a model
 

--- a/docs/nuxt/content/explanation/request-topology.md
+++ b/docs/nuxt/content/explanation/request-topology.md
@@ -96,13 +96,17 @@ Authenticated flows ride on the same topology. Tokens and cookies issued by
 Drupal are scoped to Drupal's origin: a separate-host layout needs the
 frontend to send credentials cross-origin (and CORS configured to allow
 it), while subdomain and same-origin layouts can share cookies. If
-authentication matters to your site, pick the layout first. A deployment
-models overview covering how these choices combine arrives with the
-deployment guides.
+authentication matters to your site, pick the layout first. See
+[Deployment models](/explanation/deployment-models) for how these
+choices combine.
 
 ## Where to go next
 
+- [Deployment models](/explanation/deployment-models): how these choices
+  combine into production shapes.
 - [Configure CORS in Drupal](/how-to/configure-cors) and
   [Proxy the Drupal backend](/how-to/proxy): the two implementations.
+- [Environment variables](/how-to/environment-variables): where
+  `baseUrl` comes from per environment.
 - [Troubleshoot common issues](/how-to/troubleshooting): the failure
   modes this topology produces.

--- a/docs/nuxt/content/how-to/README.md
+++ b/docs/nuxt/content/how-to/README.md
@@ -21,6 +21,8 @@ tutorial](/tutorials/getting-started).
 - [Use the Druxt client directly](/how-to/use-the-druxt-client): fetch resources without components.
 - [Use Druxt in a Node application](/how-to/use-the-node-client): run the client outside Nuxt.
 - [Explore the example apps](/how-to/example-apps): four complete reference implementations.
+- [Deploy a static site](/how-to/deploy-static): generate and host the output on a static host or CDN.
+- [Environment variables](/how-to/environment-variables): every variable a build reads, and the build-time vs runtime trap.
 - [Troubleshoot common issues](/how-to/troubleshooting): quick answers to the errors and gotchas that come up most often.
 - [Contributing](/how-to/contributing): set up a development environment and submit changes.
 

--- a/docs/nuxt/content/how-to/deploy-static.md
+++ b/docs/nuxt/content/how-to/deploy-static.md
@@ -27,7 +27,21 @@ configuration of its own.
 
 Prove the build before involving a host. Set Nuxt's target to `static`
 (`target: 'static'` in `nuxt.config.js`, or the `NUXT_TARGET` variable
-where the project reads one, as the quickstart does), then:
+where the project reads one, as the quickstart does). If the project
+enables the [API proxy](/how-to/proxy) (`druxt.proxy.api`, on by
+default in the quickstart), turn it off for static builds. The proxy is server middleware that no
+static host can run, so leaving it enabled sends the browser's API
+requests to the static host instead of Drupal. Tying it to the target keeps one config serving both modes:
+
+```js
+druxt: {
+  proxy: { api: process.env.NUXT_TARGET !== 'static' },
+},
+```
+
+Direct browser requests then need
+[CORS configured in Drupal](/how-to/configure-cors). Generate and
+serve:
 
 ```sh
 npx nuxt generate
@@ -97,7 +111,7 @@ changes.
 The same, scriptable:
 
 ```sh
-npm install --global netlify-cli
+npm install --global netlify-cli@15   # newer majors need Node 18+
 netlify init
 NODE_OPTIONS=--openssl-legacy-provider npm run generate
 netlify deploy --prod --dir=dist

--- a/docs/nuxt/content/how-to/deploy-static.md
+++ b/docs/nuxt/content/how-to/deploy-static.md
@@ -1,0 +1,157 @@
+---
+title: Deploy a static site
+weight: 3
+description: 'Generate the site and host the output on a static host or CDN, with Netlify as the worked example.'
+---
+
+> **Before you start:** read [Deployment
+> models](/explanation/deployment-models) to confirm static is your
+> model. The backend must be reachable from wherever the build runs,
+> and from visitors' browsers once deployed.
+
+`nuxt generate` renders every page to plain files in `dist/`. Any static
+host serves them; this guide uses Netlify for the worked example, and
+every step has an equivalent on Vercel, GitHub Pages or a plain web
+server.
+
+One thing static hosting does not change: **the deployed site still
+talks to Drupal.** Route lookups on client-side navigation, forms and
+authenticated content are live browser requests, so the backend you generate
+against must stay reachable from visitors' browsers, with
+[CORS configured](/how-to/configure-cors). Generating a site that needs
+no backend at all is the [fully static
+model](/explanation/deployment-models#the-three-models), a deliberate
+configuration of its own.
+
+## Generate the site locally first
+
+Prove the build before involving a host. Set Nuxt's target to `static`
+(`target: 'static'` in `nuxt.config.js`, or the `NUXT_TARGET` variable
+where the project reads one, as the quickstart does), then:
+
+```sh
+npx nuxt generate
+npx serve dist
+```
+
+Check the output before deploying:
+
+- **Every route you expect is in `dist/`.** The generator crawls links
+  from the pages it renders, so a page no link points at is not
+  generated. List extra routes explicitly if you need to:
+
+  ```js
+  import { DruxtClient } from 'druxt';
+
+  export default {
+    generate: {
+      fallback: '404.html',
+      async routes() {
+        const druxt = new DruxtClient(process.env.BASE_URL);
+        const collections = await druxt.getCollectionAll('node--article', {
+          'fields[node--article]': 'path',
+        });
+        return collections
+          .flatMap((collection) => collection.data)
+          .map((entity) => entity.attributes.path.alias)
+          .filter(Boolean);
+      },
+    },
+  };
+  ```
+
+- **The 404 fallback exists.** `generate.fallback: '404.html'` writes
+  the not-found page where static hosts expect it. This replaces the
+  default `200.html` single-page-app fallback; with every route
+  generated, you will not miss it.
+
+If the build fails reaching Drupal, see
+[the build-failure entry in Troubleshoot common issues](/how-to/troubleshooting#the-build-fails-reaching-the-backend-econnrefused-timeouts-400s).
+
+## Node version
+
+Nuxt 2 builds cleanly on Node 16. On Node 17 or later, set the OpenSSL
+legacy provider in the build command:
+
+```sh
+NODE_OPTIONS=--openssl-legacy-provider nuxt generate
+```
+
+Set the host's Node version explicitly (an `.nvmrc` file, or the host's
+`NODE_VERSION` setting) so builds do not move when the host's default
+changes.
+
+## Deploy with the Netlify UI
+
+1. Push the project to a git host and choose **Add new site → Import an
+   existing project** in Netlify.
+2. Build command: `npm run generate` (prefix with the `NODE_OPTIONS`
+   flag above if building on Node 17+). Publish directory: `dist`.
+3. Add the environment variables the build needs, at minimum `BASE_URL`
+   pointing at a Drupal the **build machine** can reach. See
+   [Environment variables](/how-to/environment-variables).
+4. Deploy. Netlify rebuilds on every push to the production branch.
+
+## Deploy with the CLI
+
+The same, scriptable:
+
+```sh
+npm install --global netlify-cli
+netlify init
+NODE_OPTIONS=--openssl-legacy-provider npm run generate
+netlify deploy --prod --dir=dist
+```
+
+## Deploy to GitHub Pages
+
+When the project already is a GitHub repository, Pages needs nothing
+outside GitHub. The gotchas to handle first are both specific to Pages:
+
+- A **project page** serves from `https://<user>.github.io/<repo>/`, a
+  subpath the build must know about. Set the router base and asset path
+  before generating:
+
+  ```js
+  export default {
+    router: { base: '/<repo>/' },
+    build: { publicPath: '/<repo>/_nuxt/' },
+  };
+  ```
+
+  A **user page** (a repository named `<user>.github.io`) serves from
+  the domain root and skips this entirely.
+
+- Pages serves `404.html` for unknown routes, so the
+  `generate.fallback: '404.html'` setting from above is already right.
+
+Then publish the generated output to the `gh-pages` branch:
+
+```sh
+npx gh-pages -d dist
+```
+
+Enable Pages for the repository (Settings → Pages → deploy from the
+`gh-pages` branch), and the site serves at the URL above. For rebuild
+automation, a GitHub Actions workflow that runs the generate and the
+`gh-pages` push on each push to your default branch replaces the manual
+command.
+
+## After the first deploy
+
+- Add your new frontend origin to the backend's
+  [CORS `allowedOrigins`](/how-to/configure-cors); the
+  [proxy](/how-to/proxy) is not available on a static host.
+- Content changes need a rebuild. Trigger one from Drupal with a build
+  hook (most static hosts issue a URL that starts a build when POSTed),
+  or on a schedule.
+- Redirects managed in Drupal's redirect module resolve through the
+  router at request time only on served pages; a static host needs them
+  exported to its own redirect configuration.
+
+## Where to go next
+
+- [Deploy your site](/tutorials/deploy-your-site): the same journey as a
+  tutorial, starting from the quickstart.
+- [The deployment models overview](/explanation/deployment-models): what
+  static does and does not give you.

--- a/docs/nuxt/content/how-to/deploy-static.md
+++ b/docs/nuxt/content/how-to/deploy-static.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a static site
 weight: 3
-description: 'Generate the site and host the output on a static host or CDN, with Netlify as the worked example.'
+description: Generate the site and host the files anywhere static. Netlify is the worked example.
 ---
 
 > **Before you start:** read [Deployment

--- a/docs/nuxt/content/how-to/environment-variables.md
+++ b/docs/nuxt/content/how-to/environment-variables.md
@@ -15,14 +15,13 @@ real environment variables. `.env` stays out of git; commit a
 
 ## The variables
 
-| Variable          | Consumed by                                        | Purpose                                                                                                                                                                                                       |
-| ----------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BASE_URL`        | `nuxt.config.js` → `druxt.baseUrl`                 | The Drupal origin, scheme included and trimmed of any trailing slash. Must be reachable from wherever the consuming code runs. [Request topology](/explanation/request-topology#baseurl-rules) has the rules. |
-| `OAUTH_CLIENT_ID` | `druxt-auth`                                       | The consumer id created in Drupal for the login flow.                                                                                                                                                         |
-| `NUXT_TARGET`     | `nuxt.config.js` → `target`                        | `static` for generated builds, unset for the node server. One config file serves both modes.                                                                                                                  |
-| `PORT`, `HOST`    | The dev and node servers                           | Where the frontend listens.                                                                                                                                                                                   |
-| `NODE_OPTIONS`    | Node itself                                        | `--openssl-legacy-provider` for building on Node 17 or later ([why](/how-to/troubleshooting#error0308010cdigital-envelope-routines-on-node-17-or-later)).                                                     |
-| `DRUXT_BASE_URL`  | [The node client CLI](/how-to/use-the-node-client) | Backend origin for `druxt-inspect`.                                                                                                                                                                           |
+| Variable          | Consumed by                        | Purpose                                                                                                                                                                                                       |
+| ----------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BASE_URL`        | `nuxt.config.js` → `druxt.baseUrl` | The Drupal origin, scheme included and trimmed of any trailing slash. Must be reachable from wherever the consuming code runs. [Request topology](/explanation/request-topology#baseurl-rules) has the rules. |
+| `OAUTH_CLIENT_ID` | `druxt-auth`                       | The consumer id created in Drupal for the login flow.                                                                                                                                                         |
+| `NUXT_TARGET`     | `nuxt.config.js` → `target`        | `static` for generated builds, unset for the node server. One config file serves both modes.                                                                                                                  |
+| `PORT`, `HOST`    | The dev and node servers           | Where the frontend listens.                                                                                                                                                                                   |
+| `NODE_OPTIONS`    | Node itself                        | `--openssl-legacy-provider` for building on Node 17 or later ([why](/how-to/troubleshooting#error0308010cdigital-envelope-routines-on-node-17-or-later)).                                                     |
 
 A copyable template:
 

--- a/docs/nuxt/content/how-to/environment-variables.md
+++ b/docs/nuxt/content/how-to/environment-variables.md
@@ -1,0 +1,72 @@
+---
+title: Environment variables
+weight: 5
+description: 'Every variable a Druxt build reads, where it comes from, and the build-time vs runtime distinction that catches people out.'
+---
+
+One page for every environment variable, so other guides can link here
+instead of repeating themselves. The quickstart writes its variables to
+a `.env` file, which Node does not read on its own: the quickstart's
+`nuxt.config.js` loads it with the `dotenv` package
+(`require('dotenv').config()`) and then reads plain `process.env`
+values. Deployment platforms skip the file and inject their settings as
+real environment variables. `.env` stays out of git; commit a
+`.env.example` with placeholders instead.
+
+## The variables
+
+| Variable          | Consumed by                                        | Purpose                                                                                                                                                                                                       |
+| ----------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BASE_URL`        | `nuxt.config.js` → `druxt.baseUrl`                 | The Drupal origin, scheme included and trimmed of any trailing slash. Must be reachable from wherever the consuming code runs. [Request topology](/explanation/request-topology#baseurl-rules) has the rules. |
+| `OAUTH_CLIENT_ID` | `druxt-auth`                                       | The consumer id created in Drupal for the login flow.                                                                                                                                                         |
+| `NUXT_TARGET`     | `nuxt.config.js` → `target`                        | `static` for generated builds, unset for the node server. One config file serves both modes.                                                                                                                  |
+| `PORT`, `HOST`    | The dev and node servers                           | Where the frontend listens.                                                                                                                                                                                   |
+| `NODE_OPTIONS`    | Node itself                                        | `--openssl-legacy-provider` for building on Node 17 or later ([why](/how-to/troubleshooting#error0308010cdigital-envelope-routines-on-node-17-or-later)).                                                     |
+| `DRUXT_BASE_URL`  | [The node client CLI](/how-to/use-the-node-client) | Backend origin for `druxt-inspect`.                                                                                                                                                                           |
+
+A copyable template:
+
+```sh
+# .env
+BASE_URL=https://cms.example.com
+OAUTH_CLIENT_ID=
+# NUXT_TARGET=static
+```
+
+Never commit real secrets; keep per-environment values in the
+platform's settings, and put anything sensitive only there.
+
+## Build time vs runtime
+
+**Nuxt 2 bakes `process.env` values into the bundle at build time.** A
+`baseUrl` read from `BASE_URL` in `nuxt.config.js` is fixed at the moment
+you run `nuxt build` or `nuxt generate`. Changing the variable on the
+server later has no effect until the next build.
+
+This is the most common deployment trap: one build promoted
+through staging and production keeps talking to the backend it was built
+against. The options:
+
+- **One build per environment**, each built with its own `BASE_URL`.
+  Simple, and the only option for generated static sites, since their
+  pages are rendered against one backend by definition.
+- **Runtime config** for server deployments: values under
+  `publicRuntimeConfig` and `privateRuntimeConfig` in `nuxt.config.js`
+  are read when the server starts, not when it was built, and code
+  reads them through `this.$config` (such as `this.$config.baseUrl`)
+  instead of `process.env`. Use
+  `publicRuntimeConfig` for values the browser may see and
+  `privateRuntimeConfig` for server-only secrets (service accounts,
+  API keys used in server middleware).
+
+The build machine and the visitor's browser both use `baseUrl`, and
+they may not be able to reach the same address. See
+[Request topology](/explanation/request-topology#baseurl-rules) for the
+layouts that resolve this.
+
+## Where to go next
+
+- [Deploy a static site](/how-to/deploy-static): where these variables
+  get set on a host.
+- [Prepare the Drupal backend](/how-to/prepare-the-backend): the Drupal
+  side of `BASE_URL` and `OAUTH_CLIENT_ID`.

--- a/docs/nuxt/content/how-to/troubleshooting.md
+++ b/docs/nuxt/content/how-to/troubleshooting.md
@@ -117,8 +117,9 @@ NODE_OPTIONS=--openssl-legacy-provider nuxt build
 ```
 
 This also works in CI and static-host build settings by prefixing the
-build command. Pin the build host's Node version explicitly so this
-stays predictable.
+build command; [Deploy a static
+site](/how-to/deploy-static#node-version) covers pinning the host's
+Node version so this stays predictable.
 
 ## Builds fail on Windows
 

--- a/docs/nuxt/content/tutorials/README.md
+++ b/docs/nuxt/content/tutorials/README.md
@@ -17,6 +17,8 @@ lesson.
   `DruxtModule` to create your own Druxt-powered components.
 - [Add a login flow](/tutorials/authentication): turn the quickstart's
   already-configured OAuth setup into a real, working login.
+- [Deploy your site](/tutorials/deploy-your-site): take the quickstart
+  from localhost to a live URL on a free static host.
 
 If you already have a site running and want to accomplish a specific task,
 see the [How-to guides](/how-to). To understand _why_ Druxt works the way it

--- a/docs/nuxt/content/tutorials/authentication.md
+++ b/docs/nuxt/content/tutorials/authentication.md
@@ -110,7 +110,8 @@ rather than requiring people to know the `/user/login` URL by heart.
 
 ## Where to go next
 
-- Keep learning: [Build a custom Druxt module](/tutorials/first-custom-module).
+- Keep learning: [Deploy your site](/tutorials/deploy-your-site), the
+  final lesson.
 - See this flow put to work in a real app: [Explore the example
   apps](/how-to/example-apps): Content Ops Console uses this exact login to
   authenticate its inline content editing.

--- a/docs/nuxt/content/tutorials/deploy-your-site.md
+++ b/docs/nuxt/content/tutorials/deploy-your-site.md
@@ -26,7 +26,7 @@ slow part.
 ## 1. Tell Nuxt what to generate
 
 The quickstart's routes come from Drupal, so the static generator needs
-a starting point to crawl from. Add two lines to `nuxt/nuxt.config.js`,
+a starting point to crawl from. Add this line to `nuxt/nuxt.config.js`,
 just inside `export default {`:
 
 ```js
@@ -37,6 +37,20 @@ generate: { fallback: '404.html', routes: ['/'] },
 rest by following links. `fallback: '404.html'` writes the not-found
 page where static hosts expect it (this replaces the default `200.html`
 single-page-app fallback).
+
+Then find the `proxy` setting inside the `druxt` block and tie it to
+the build target:
+
+```js
+proxy: {
+  api: process.env.NUXT_TARGET !== 'static'
+},
+```
+
+The proxy is server middleware that no static host can run. With this
+line, development keeps the proxy, and the static build has the browser
+talk to Drupal directly (the demo backend used later answers any
+origin).
 
 ## 2. Generate locally and prove the dependency
 
@@ -92,8 +106,14 @@ Expect the crawler to find and render the demo's pages this time; the
 generated homepage carries the Umami menu. Deploy the output:
 
 ```sh
-npm install --global netlify-cli
+npm install --global netlify-cli@15
 netlify login
+```
+
+(Newer Netlify CLI majors need Node 18 and later; 15 is the last line
+that runs on the Node 16 this stack pins.)
+
+```sh
 netlify deploy --prod --dir=nuxt/dist
 ```
 

--- a/docs/nuxt/content/tutorials/deploy-your-site.md
+++ b/docs/nuxt/content/tutorials/deploy-your-site.md
@@ -1,0 +1,141 @@
+---
+title: Deploy your site
+weight: -6
+description: Generate the quickstart as static files, prove why the backend still matters, and put a working Druxt site on a live URL.
+---
+
+The [first tutorial](/tutorials/getting-started) ended with a site running
+on your machine. This lesson takes the next step: generating the site as static files
+and finishing with a working Druxt site on a public URL. It also proves
+why the backend still matters.
+
+One constraint shapes the lesson. A Druxt site needs its backend even
+after generating, because route lookups on navigation and live data are
+browser requests. Your throwaway backend runs on your machine, where
+the internet cannot reach it, so the live deploy in step 3 points at
+the public Druxt demo backend instead. Your own article stays local for
+now, and step 4 covers what publishing your own content takes.
+
+**What you need:** the completed [Getting
+started](/tutorials/getting-started) setup with its backend provisioned
+and running (`npm run info` shows its status), a
+[Netlify](https://www.netlify.com) account, permission to install npm
+packages globally, and about half an hour. The generate runs are the
+slow part.
+
+## 1. Tell Nuxt what to generate
+
+The quickstart's routes come from Drupal, so the static generator needs
+a starting point to crawl from. Add two lines to `nuxt/nuxt.config.js`,
+just inside `export default {`:
+
+```js
+generate: { fallback: '404.html', routes: ['/'] },
+```
+
+`routes: ['/']` seeds the crawler with the homepage; it discovers the
+rest by following links. `fallback: '404.html'` writes the not-found
+page where static hosts expect it (this replaces the default `200.html`
+single-page-app fallback).
+
+## 2. Generate locally and prove the dependency
+
+Check the backend is up (`npm run info`), then generate from the project
+root:
+
+```sh
+NUXT_TARGET=static NODE_OPTIONS=--openssl-legacy-provider npm run generate --prefix nuxt
+```
+
+Nuxt renders your pages, your article included, into `nuxt/dist/` as
+plain HTML, CSS and JavaScript. Serve it and click around:
+
+```sh
+npx serve nuxt/dist
+```
+
+Now stop the backend (`npm run stop`) and reload. The page you are on
+still renders, and navigation breaks. Generated pages are baked files, but
+moving between them still asks Drupal to resolve the route. That is the
+dependency the rest of this lesson works around, and the reason step 3
+uses a backend that browsers can reach.
+
+Start the backend again for good measure: `npm run dev`, then Ctrl+C
+once it is up (the frontend stops; the backend keeps serving, which is
+what `npm run stop` is for).
+
+## 3. Deploy against the public demo backend
+
+The Druxt demo backend at `https://demo-api.druxtjs.org` is public,
+answers browsers from any origin, and runs the Umami food-magazine demo
+content. Pointing your frontend at it takes a theme change and an
+environment override.
+
+First, its blocks and menus belong to Drupal's `umami` theme, and a
+Druxt frontend renders the block layout of whatever theme it is told
+about. In `nuxt/nuxt.config.js`, find `site: { theme: 'olivero' }` and
+change it:
+
+```js
+theme: 'umami';
+```
+
+Second, generate against the demo backend. Passing `BASE_URL` on the
+command line overrides `.env` for this run only, so nothing needs
+editing back afterwards:
+
+```sh
+BASE_URL=https://demo-api.druxtjs.org NUXT_TARGET=static NODE_OPTIONS=--openssl-legacy-provider npm run generate --prefix nuxt
+```
+
+Expect the crawler to find and render the demo's pages this time; the
+generated homepage carries the Umami menu. Deploy the output:
+
+```sh
+npm install --global netlify-cli
+netlify login
+netlify deploy --prod --dir=nuxt/dist
+```
+
+Answer the prompts to create a new site. The printed URL is a working
+Druxt site on the internet: pages pre-rendered, menu live, navigation
+resolving routes against the demo backend from your visitors' browsers.
+If something fails, [Troubleshoot common
+issues](/how-to/troubleshooting) covers the build and CORS failure
+modes; if the demo backend itself is unreachable, the deploy still
+serves its generated pages, and navigation degrades until it returns.
+
+Change `theme` back to `olivero` when you return to local work.
+
+## 4. Publishing your own content
+
+To put **your** content on that URL, your backend has to live somewhere
+browsers can reach. The realistic options:
+
+- **Host Drupal, keep the frontend static.** Any Drupal host works
+  ([prepare the backend](/how-to/prepare-the-backend),
+  [configure CORS](/how-to/configure-cors)); point `BASE_URL` at it,
+  generate, deploy, rebuild when content changes. This is the most
+  common production shape.
+- **Host both halves as servers.** A node service renders live content
+  next to hosted Drupal.
+- **A databaseless backend.** Drupal can exist only at build time, its
+  content exported to files with
+  [Tome](https://tome.fyi), and the
+  [quickstart-druxt-site-tome](https://github.com/druxt/quickstart-druxt-site-tome)
+  starter is this shape. Freeing the result from any backend also means
+  disabling the router middleware, covered under the fully static
+  model.
+
+[Deployment models](/explanation/deployment-models) compares the three
+and hands off to the deploy guides.
+
+## Where to go next
+
+- [Deployment models](/explanation/deployment-models): choose the shape
+  for your real site.
+- [Deploy a static site](/how-to/deploy-static): the production version
+  of this lesson, with git-driven builds and rebuild hooks.
+- [Prepare the Drupal backend](/how-to/prepare-the-backend): make a real
+  Drupal site Druxt-ready.
+- Back to [the tutorials index](/tutorials).

--- a/docs/nuxt/content/tutorials/deploy-your-site.md
+++ b/docs/nuxt/content/tutorials/deploy-your-site.md
@@ -141,7 +141,7 @@ browsers can reach. The realistic options:
   next to hosted Drupal.
 - **A databaseless backend.** Drupal can exist only at build time, its
   content exported to files with
-  [Tome](https://tome.fyi), and the
+  [Tome](https://www.drupal.org/project/tome), and the
   [quickstart-druxt-site-tome](https://github.com/druxt/quickstart-druxt-site-tome)
   starter is this shape. Freeing the result from any backend also means
   disabling the router middleware, covered under the fully static

--- a/docs/nuxt/content/tutorials/first-custom-module.md
+++ b/docs/nuxt/content/tutorials/first-custom-module.md
@@ -197,3 +197,5 @@ The same three ideas power every Druxt module in the
   [Component resolution](/explanation/component-resolution).
 - Read the base class reference:
   [DruxtModule API](/api/packages/druxt/components/DruxtModule).
+- Keep learning: [Add a login flow](/tutorials/authentication), the
+  next lesson.

--- a/docs/nuxt/content/tutorials/getting-started.md
+++ b/docs/nuxt/content/tutorials/getting-started.md
@@ -139,6 +139,8 @@ is the only file you'd change to point the frontend at a different Drupal.
   the next lesson.
 - Log a user in: [Add a login flow](/tutorials/authentication): the OAuth
   setup this command already provisioned, put to use.
+- Put it online: [Deploy your site](/tutorials/deploy-your-site), the
+  deployment lesson.
 - Understand the machine you just started:
   [Architecture](/explanation/architecture).
 - Start customizing the look: [Theme Druxt components](/how-to/theming).


### PR DESCRIPTION
Wave 2 of the docs programme, stacked on #800.

- Deployment models explanation: fully static, static plus live backend, server-rendered
- Deploy your site tutorial, generating against the demo backend and deploying with the Netlify CLI
- Deploy a static site how-to, including a GitHub Pages lane
- Environment variables reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on choosing between static, hybrid, and server-rendered deployment models.
  - Added guides for deploying static sites, configuring environment variables, and troubleshooting deployment issues.
  - Added a tutorial covering deployment from local development to a live site.
  - Updated documentation navigation and follow-up links to make deployment resources easier to discover.
  - Expanded guidance on authentication, request layouts, hosting options, redirects, CORS, and runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->