### PR TITLE
docs: authentication cookbook, server deployment and the compatibility matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-weight: 5
+weight: 8
 ---
 
 > All contributions are welcomed and appreciated.

--- a/docs/nuxt/content/explanation/README.md
+++ b/docs/nuxt/content/explanation/README.md
@@ -21,7 +21,7 @@ instructions. For doing, see the [How-to guides](/how-to).
   data source.
 - [Component resolution](/explanation/component-resolution): wrapper
   discovery and the theme layer.
-- [Request topology](/explanation/request-topology): build, server and
-  browser requests, and what that means for CORS, the proxy and hosting.
-- [Deployment models](/explanation/deployment-models): fully static,
-  static with a live backend, or server-rendered, and how to choose.
+- [Request topology](/explanation/request-topology): which requests
+  happen where, and why CORS only ever bites in the browser.
+- [Deployment models](/explanation/deployment-models): three production
+  shapes and the decision framework between them.

--- a/docs/nuxt/content/explanation/deployment-models.md
+++ b/docs/nuxt/content/explanation/deployment-models.md
@@ -53,7 +53,8 @@ server fallback. One build serves generated pages from a web server with
 long cache headers, and a node service behind it catches routes that
 were not generated, such as authenticated pages. Nuxt's `target` option
 (the build target) can be driven by an environment variable so one
-`nuxt.config.js` serves all modes.
+`nuxt.config.js` serves all modes; [Deploy a server-rendered
+site](/how-to/deploy-server) shows the working shape.
 
 ## Choosing a model
 
@@ -87,6 +88,8 @@ so the data half of that is ready.
 
 - [Deploy a static site](/how-to/deploy-static): the generate-and-host
   procedure.
+- [Deploy a server-rendered site](/how-to/deploy-server): the node
+  service and the hybrid.
 - [Environment variables](/how-to/environment-variables): what each
   build needs to know.
 - [The deploy-your-site tutorial](/tutorials/deploy-your-site): this

--- a/docs/nuxt/content/how-to/README.md
+++ b/docs/nuxt/content/how-to/README.md
@@ -22,6 +22,8 @@ tutorial](/tutorials/getting-started).
 - [Use Druxt in a Node application](/how-to/use-the-node-client): run the client outside Nuxt.
 - [Explore the example apps](/how-to/example-apps): four complete reference implementations.
 - [Deploy a static site](/how-to/deploy-static): generate and host the output on a static host or CDN.
+- [Deploy a server-rendered site](/how-to/deploy-server): run the node service behind a web server, or the static-plus-fallback hybrid.
+- [Authenticate users with OAuth](/how-to/authentication): the full Simple OAuth setup from scratch, both sides.
 - [Environment variables](/how-to/environment-variables): every variable a build reads, and the build-time vs runtime trap.
 - [Troubleshoot common issues](/how-to/troubleshooting): quick answers to the errors and gotchas that come up most often.
 - [Contributing](/how-to/contributing): set up a development environment and submit changes.

--- a/docs/nuxt/content/how-to/README.md
+++ b/docs/nuxt/content/how-to/README.md
@@ -4,8 +4,8 @@ weight: -10
 description: Goal-oriented recipes for specific tasks, assuming a working Druxt site.
 ---
 
-How-to guides are **goal-oriented**: each one starts from a real-world goal
-and ends with that goal achieved. They assume you already have a working
+How-to guides are **goal-oriented**: recipes for a task you already
+have, not lessons. They assume you already have a working
 Druxt site; if you don't, start with the [Getting started
 tutorial](/tutorials/getting-started).
 
@@ -21,8 +21,8 @@ tutorial](/tutorials/getting-started).
 - [Use the Druxt client directly](/how-to/use-the-druxt-client): fetch resources without components.
 - [Use Druxt in a Node application](/how-to/use-the-node-client): run the client outside Nuxt.
 - [Explore the example apps](/how-to/example-apps): four complete reference implementations.
-- [Deploy a static site](/how-to/deploy-static): generate and host the output on a static host or CDN.
-- [Deploy a server-rendered site](/how-to/deploy-server): run the node service behind a web server, or the static-plus-fallback hybrid.
+- [Deploy a static site](/how-to/deploy-static): the worked Netlify example, from local proof to rebuild hooks.
+- [Deploy a server-rendered site](/how-to/deploy-server): the node service behind nginx, and the hybrid with a server fallback.
 - [Authenticate users with OAuth](/how-to/authentication): the full Simple OAuth setup from scratch, both sides.
 - [Environment variables](/how-to/environment-variables): every variable a build reads, and the build-time vs runtime trap.
 - [Troubleshoot common issues](/how-to/troubleshooting): quick answers to the errors and gotchas that come up most often.

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -7,7 +7,10 @@ description: 'The full OAuth setup from scratch: Simple OAuth keys, scopes and a
 > **Before you start:** the [login flow
 > tutorial](/tutorials/authentication) uses the quickstart's ready-made
 > OAuth setup. This guide builds that setup from scratch on your own
-> backend, and covers the failure modes people actually hit.
+> backend. Drupal-side commands run in the Drupal project root, with
+> [drush](https://www.drush.org) installed
+> (`composer require drush/drush`); if the backend runs in a container,
+> prefix them with your tool's exec command.
 
 Druxt authenticates with OAuth 2 Authorization Code + PKCE:
 [Simple OAuth](https://www.drupal.org/project/simple_oauth) on the Drupal
@@ -16,35 +19,46 @@ side, [druxt-auth](https://github.com/druxt/druxt-auth) (built on
 
 ## Drupal: install and generate keys
 
+Simple OAuth 6 requires Drupal core 10.3 or later.
+
 ```sh
 composer require drupal/simple_oauth:^6
-drush pm:enable simple_oauth
+drush pm:enable simple_oauth -y
+mkdir ../keys
 drush simple-oauth:generate-keys ../keys
 ```
 
-Keys belong **outside the web root** (`../keys` relative to it), and
-never in git; production sites commit only a deny-rule placeholder in
-that directory and deploy real keys out of band. If key generation fails
-on Windows, generate under WSL2; native OpenSSL setups there have
-repeatedly produced broken keys that surface later as opaque frontend
-errors.
+The key pair belongs **outside the web root**; `../keys` here sits next
+to Drupal's `web/` directory, not inside it. The directory must exist
+before the command runs, and the keys never go in git. If a key file
+must live under a served path for platform reasons, commit only a
+web-server deny rule for the directory (an `.htaccess` stub on Apache;
+an equivalent server rule on nginx). If key generation fails on Windows,
+generate under WSL2; native OpenSSL setups there have repeatedly
+produced broken keys that surface later as opaque frontend errors.
 
-Short access tokens with longer refresh tokens are the production norm
-(minutes and hours respectively); set both in the Simple OAuth settings.
+Set the token lifetimes on the settings form at
+`/admin/config/people/simple_oauth`: short access tokens with longer
+refresh tokens (minutes and hours respectively) limit the damage of a
+leaked token while keeping sessions usable.
 
 ## Drupal: create a scope
 
 Simple OAuth 6 refuses any authorization request it cannot resolve a
 scope for, and **a fresh site ships no scopes**, so every login fails
-with "Check the `scope` parameter" until one exists. Create one (Drupal
-→ Administration → Configuration → People → Simple OAuth → Scopes, or
-programmatically): grant types `authorization_code` and `refresh_token`,
-granularity **role**, mapped to the role your users hold (for example
-`authenticated`).
+with "Check the `scope` parameter" until one exists. Create one at
+`/admin/config/people/simple_oauth/oauth2_scope`: grant types
+`authorization_code` and `refresh_token`, granularity **role**, mapped
+to the role your users hold. Drupal ships two built-in roles, Anonymous
+and Authenticated, and permissions attach to roles; `authenticated` is
+the usual mapping here.
 
 ## Drupal: create the consumer
 
-Create a Consumer (Drupal → Configuration → Web services → Consumers):
+A Consumer is Drupal's entity for one registered OAuth client; the
+`consumers` module providing it installs with Simple OAuth. Create one
+at `/admin/config/services/consumers` (an administrator account is
+needed for all of these forms):
 
 | Field | Value |
 | ----- | ----- |
@@ -52,27 +66,33 @@ Create a Consumer (Drupal → Configuration → Web services → Consumers):
 | Secret | Empty. A browser app cannot keep a secret; PKCE replaces it |
 | Confidential | Off |
 | PKCE | On |
-| Scopes | The scope you created, as the default |
+| Scopes | The scope you created, set as the consumer's default |
 | Redirect URI | `https://your-frontend/callback`, one per environment |
 
-Every frontend origin that logs in (production, previews, `localhost`)
-needs its redirect URI registered; production setups keep one consumer
-per environment.
+Every frontend origin that logs in needs its redirect URI registered;
+the origins people forget are previews and `http://localhost:3000`.
+Production setups keep one consumer per environment.
 
 ## Nuxt: configure druxt-auth
 
+Options are flat, and the module goes in `modules`, not `buildModules`:
+it registers server middleware that `nuxt start` only loads from
+`modules`.
+
 ```js
 export default {
-  buildModules: [
-    ['druxt-auth', {
-      auth: {
-        clientId: process.env.OAUTH_CLIENT_ID,
-        scope: ['druxt'],
-      },
-    }],
+  modules: [
+    ['druxt-auth', { clientId: process.env.OAUTH_CLIENT_ID }],
   ],
 }
 ```
+
+No `scope` option is needed: when the app sends none, Drupal applies
+the consumer's default scopes, which is why the table above sets your
+scope as the default. Pass `scope: ['<machine-name>']` only when one
+consumer serves several scopes and this app must pick; the value must
+equal the scope's machine name in Drupal, or logins fail with the same
+"Check the `scope` parameter" error.
 
 The module registers two strategies: `drupal-authorization_code` (the
 PKCE flow above, the right default) and `drupal-password` (server-side
@@ -87,34 +107,32 @@ The `/callback` route is handled for you.
 ## The login page trap
 
 A "Log in" menu link pointing at `/user/login` fails: Decoupled Router
-has no resolver for Drupal's user routes, so the frontend request for
+(the Drupal module that [resolves paths](/explanation/routing) for the
+frontend) has no resolver for Drupal's user routes, so the request for
 that path errors. Either create your own page at `pages/user/login.vue`
 that calls `loginWith`, or point the menu link somewhere the frontend
-owns. There is no default login page; every site provides its own.
+owns. There is no default login page to fall back on.
 
 ## Which requests carry the token
 
-Logging in gives the app a Bearer token, and `@nuxtjs/auth-next` attaches
-it to its own requests (the userinfo endpoint, proxied through the
-frontend by druxt-auth). Druxt's JSON:API traffic goes through the
-[DruxtClient](/how-to/use-the-druxt-client)'s own axios instance, so to
-fetch access-controlled content as the logged-in user, attach the token
-there with a plugin:
+On login, `@nuxtjs/auth-next` sets the `Authorization` header on the
+app's shared axios instance, and Druxt's client uses that same instance
+by default, so JSON:API requests for entities, menus and routes carry
+the token automatically. Drupal then applies the user's real permissions
+to every response. Two caveats:
 
-```js
-// plugins/druxt-auth-token.js
-export default ({ $auth, $druxt }) => {
-  $druxt.axios.interceptors.request.use((config) => {
-    if ($auth.loggedIn) {
-      config.headers.Authorization = $auth.strategy.token.get()
-    }
-    return config
-  })
-}
-```
+- The header is global to that instance. Requests your app makes to
+  third-party APIs through the same `$axios` carry the user's token
+  too; give those a separate axios instance.
+- Configuring `druxt.axios` in `nuxt.config.js` makes the DruxtClient
+  create its own instance, and the automatic header no longer reaches
+  it. Either keep the default wiring, or attach the token explicitly
+  with `$druxt.addHeaders({ Authorization: this.$auth.strategy.token.get() })`.
 
-Drupal then applies the user's real permissions to every response,
-including menus and routes.
+The userinfo endpoint is proxied through the frontend only when the
+[API proxy](/how-to/proxy) is enabled; without it the browser calls
+Drupal's `/oauth/userinfo` cross-origin, which needs
+[CORS](/how-to/configure-cors).
 
 ## Writes, and the CSRF question
 
@@ -122,11 +140,11 @@ Form submissions through `DruxtEntityForm` are JSON:API writes.
 [Enable writes](/how-to/prepare-the-backend#check-the-jsonapi-settings)
 (`read_only: 0`) first. With **Bearer token** authentication, no CSRF
 token is needed; Drupal's CSRF protection applies to **cookie**
-sessions. A 403 naming `X-CSRF-Token` means the request authenticated by
-cookie (typically a session shared with the Drupal domain) rather than
-by the OAuth header: attach the Bearer token as above, or fetch a CSRF
-token from Drupal's `/session/token` and send it in the `X-CSRF-Token`
-header alongside cookie auth.
+sessions. A 403 naming `X-CSRF-Token` means the request authenticated
+by cookie (typically a session shared with the Drupal domain) rather
+than by the OAuth header: attach the Bearer token as above, or fetch a
+CSRF token from Drupal's `/session/token` and send it in the
+`X-CSRF-Token` header alongside cookie auth.
 
 ## Logging out
 
@@ -142,4 +160,4 @@ immediately should force a reload or flush the affected resources.
 - [Request topology](/explanation/request-topology#cookies-and-sessions):
   how hosting layout affects cookies and credentialed CORS.
 - [druxt-auth README](https://github.com/druxt/druxt-auth): every module
-  option.
+  option, including the password-grant strategy's server-side secret.

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -1,0 +1,145 @@
+---
+title: Authenticate users with OAuth
+weight: 0
+description: 'The full OAuth setup from scratch: Simple OAuth keys, scopes and a consumer in Drupal, druxt-auth in Nuxt, and the traps on both sides.'
+---
+
+> **Before you start:** the [login flow
+> tutorial](/tutorials/authentication) uses the quickstart's ready-made
+> OAuth setup. This guide builds that setup from scratch on your own
+> backend, and covers the failure modes people actually hit.
+
+Druxt authenticates with OAuth 2 Authorization Code + PKCE:
+[Simple OAuth](https://www.drupal.org/project/simple_oauth) on the Drupal
+side, [druxt-auth](https://github.com/druxt/druxt-auth) (built on
+`@nuxtjs/auth-next`) on the Nuxt side.
+
+## Drupal: install and generate keys
+
+```sh
+composer require drupal/simple_oauth:^6
+drush pm:enable simple_oauth
+drush simple-oauth:generate-keys ../keys
+```
+
+Keys belong **outside the web root** (`../keys` relative to it), and
+never in git; production sites commit only a deny-rule placeholder in
+that directory and deploy real keys out of band. If key generation fails
+on Windows, generate under WSL2; native OpenSSL setups there have
+repeatedly produced broken keys that surface later as opaque frontend
+errors.
+
+Short access tokens with longer refresh tokens are the production norm
+(minutes and hours respectively); set both in the Simple OAuth settings.
+
+## Drupal: create a scope
+
+Simple OAuth 6 refuses any authorization request it cannot resolve a
+scope for, and **a fresh site ships no scopes**, so every login fails
+with "Check the `scope` parameter" until one exists. Create one (Drupal
+→ Administration → Configuration → People → Simple OAuth → Scopes, or
+programmatically): grant types `authorization_code` and `refresh_token`,
+granularity **role**, mapped to the role your users hold (for example
+`authenticated`).
+
+## Drupal: create the consumer
+
+Create a Consumer (Drupal → Configuration → Web services → Consumers):
+
+| Field | Value |
+| ----- | ----- |
+| Client ID | A stable id your frontend will use; generate a UUID |
+| Secret | Empty. A browser app cannot keep a secret; PKCE replaces it |
+| Confidential | Off |
+| PKCE | On |
+| Scopes | The scope you created, as the default |
+| Redirect URI | `https://your-frontend/callback`, one per environment |
+
+Every frontend origin that logs in (production, previews, `localhost`)
+needs its redirect URI registered; production setups keep one consumer
+per environment.
+
+## Nuxt: configure druxt-auth
+
+```js
+export default {
+  buildModules: [
+    ['druxt-auth', {
+      auth: {
+        clientId: process.env.OAUTH_CLIENT_ID,
+        scope: ['druxt'],
+      },
+    }],
+  ],
+}
+```
+
+The module registers two strategies: `drupal-authorization_code` (the
+PKCE flow above, the right default) and `drupal-password` (server-side
+password grant). Trigger a login from any component:
+
+```js
+this.$auth.loginWith('drupal-authorization_code')
+```
+
+The `/callback` route is handled for you.
+
+## The login page trap
+
+A "Log in" menu link pointing at `/user/login` fails: Decoupled Router
+has no resolver for Drupal's user routes, so the frontend request for
+that path errors. Either create your own page at `pages/user/login.vue`
+that calls `loginWith`, or point the menu link somewhere the frontend
+owns. There is no default login page; every site provides its own.
+
+## Which requests carry the token
+
+Logging in gives the app a Bearer token, and `@nuxtjs/auth-next` attaches
+it to its own requests (the userinfo endpoint, proxied through the
+frontend by druxt-auth). Druxt's JSON:API traffic goes through the
+[DruxtClient](/how-to/use-the-druxt-client)'s own axios instance, so to
+fetch access-controlled content as the logged-in user, attach the token
+there with a plugin:
+
+```js
+// plugins/druxt-auth-token.js
+export default ({ $auth, $druxt }) => {
+  $druxt.axios.interceptors.request.use((config) => {
+    if ($auth.loggedIn) {
+      config.headers.Authorization = $auth.strategy.token.get()
+    }
+    return config
+  })
+}
+```
+
+Drupal then applies the user's real permissions to every response,
+including menus and routes.
+
+## Writes, and the CSRF question
+
+Form submissions through `DruxtEntityForm` are JSON:API writes.
+[Enable writes](/how-to/prepare-the-backend#check-the-jsonapi-settings)
+(`read_only: 0`) first. With **Bearer token** authentication, no CSRF
+token is needed; Drupal's CSRF protection applies to **cookie**
+sessions. A 403 naming `X-CSRF-Token` means the request authenticated by
+cookie (typically a session shared with the Drupal domain) rather than
+by the OAuth header: attach the Bearer token as above, or fetch a CSRF
+token from Drupal's `/session/token` and send it in the `X-CSRF-Token`
+header alongside cookie auth.
+
+## Logging out
+
+`this.$auth.logout()` ends the frontend session. Data fetched while
+logged in stays in the [DruxtStore](/explanation/druxt-store) until the
+page reloads; a logout flow that must drop privileged content
+immediately should force a reload or flush the affected resources.
+
+## Where to go next
+
+- [Add a login flow](/tutorials/authentication): the tutorial version on
+  the quickstart.
+- [Request topology](/explanation/request-topology#cookies-and-sessions):
+  how hosting layout affects cookies and credentialed CORS.
+- [druxt-auth README](https://github.com/druxt/druxt-auth): every module
+  option.

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -45,20 +45,20 @@ leaked token while keeping sessions usable.
 ## Drupal: create a scope
 
 Simple OAuth 6 refuses any authorization request it cannot resolve a
-scope for, and **a fresh site ships no scopes**, so every login fails
+scope for, and **a fresh site has an empty scope list**, so every login fails
 with "Check the `scope` parameter" until one exists. Create one at
 `/admin/config/people/simple_oauth/oauth2_scope`: grant types
-`authorization_code` and `refresh_token`, granularity **role**, mapped
-to the role your users hold. Drupal ships two built-in roles, Anonymous
-and Authenticated, and permissions attach to roles; `authenticated` is
-the usual mapping here.
+`authorization_code` and `refresh_token`, with the `granularity` field
+set to **role** and mapped to the role your users hold. Drupal has two
+built-in roles, Anonymous and Authenticated, and permissions attach to
+roles, so `authenticated` is the usual mapping here.
 
 ## Drupal: create the consumer
 
-A Consumer is Drupal's entity for one registered OAuth client; the
-`consumers` module providing it installs with Simple OAuth. Create one
-at `/admin/config/services/consumers` (an administrator account is
-needed for all of these forms):
+A Consumer is Drupal's entity for one registered OAuth client, provided
+by the `consumers` module that arrives as a Simple OAuth dependency.
+Create one at `/admin/config/services/consumers` (an administrator
+account is needed for all of these forms):
 
 | Field | Value |
 | ----- | ----- |
@@ -87,9 +87,9 @@ export default {
 }
 ```
 
-No `scope` option is needed: when the app sends none, Drupal applies
-the consumer's default scopes, which is why the table above sets your
-scope as the default. Pass `scope: ['<machine-name>']` only when one
+No `scope` option is needed. When the app sends none, Drupal applies
+the consumer's default scopes, and the consumer table above made your
+scope that default. Pass `scope: ['<machine-name>']` only when one
 consumer serves several scopes and this app must pick; the value must
 equal the scope's machine name in Drupal, or logins fail with the same
 "Check the `scope` parameter" error.
@@ -113,17 +113,17 @@ that path errors. Either create your own page at `pages/user/login.vue`
 that calls `loginWith`, or point the menu link somewhere the frontend
 owns. There is no default login page to fall back on.
 
-## Which requests carry the token
+## Which requests send the token
 
 On login, `@nuxtjs/auth-next` sets the `Authorization` header on the
 app's shared axios instance, and Druxt's client uses that same instance
 by default, so JSON:API requests for entities, menus and routes carry
 the token automatically. Drupal then applies the user's real permissions
-to every response. Two caveats:
+to every response. The caveats:
 
 - The header is global to that instance. Requests your app makes to
-  third-party APIs through the same `$axios` carry the user's token
-  too; give those a separate axios instance.
+  third-party APIs through the same `$axios` include the user's token
+  too. Give those a separate axios instance.
 - Configuring `druxt.axios` in `nuxt.config.js` makes the DruxtClient
   create its own instance, and the automatic header no longer reaches
   it. Either keep the default wiring, or attach the token explicitly

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -93,9 +93,13 @@ consumer serves several scopes and this app must pick; the value must
 equal the scope's machine name in Drupal, or logins fail with the same
 "Check the `scope` parameter" error.
 
-The module registers two strategies: `drupal-authorization_code` (the
-PKCE flow above, the right default) and `drupal-password` (server-side
-password grant). Trigger a login from any component:
+The module registers two strategies. `drupal-authorization_code` is the
+PKCE flow above and the one to use. `drupal-password` (server-side
+password grant) does not work against the backend this page builds:
+Simple OAuth 6 removed the password grant (its remaining grants are
+authorization code, client credentials and refresh token), so that
+strategy only functions against a Simple OAuth 5.x backend. Trigger a
+login from any component:
 
 ```js
 this.$auth.loginWith('drupal-authorization_code');
@@ -159,4 +163,4 @@ immediately should force a reload or flush the affected resources.
 - [Request topology](/explanation/request-topology#cookies-and-sessions):
   how hosting layout affects cookies and credentialed CORS.
 - [druxt-auth README](https://github.com/druxt/druxt-auth): every module
-  option, including the password-grant strategy's server-side secret.
+  option.

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -19,10 +19,11 @@ side, [druxt-auth](https://github.com/druxt/druxt-auth) (built on
 
 ## Drupal: install and generate keys
 
-Simple OAuth 6 requires Drupal core 10.3 or later.
+Simple OAuth 6.1, the current 6.x line, requires Drupal core 10.3 or
+later (6.0 accepted 10.2).
 
 ```sh
-composer require drupal/simple_oauth:^6
+composer require drupal/simple_oauth:^6.1
 drush pm:enable simple_oauth -y
 mkdir ../keys
 drush simple-oauth:generate-keys ../keys

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Authenticate users with OAuth
-weight: 0
+weight: 5
 description: 'The full OAuth setup from scratch: Simple OAuth keys, scopes and a consumer in Drupal, druxt-auth in Nuxt, and the traps on both sides.'
 ---
 
@@ -60,14 +60,14 @@ by the `consumers` module that arrives as a Simple OAuth dependency.
 Create one at `/admin/config/services/consumers` (an administrator
 account is needed for all of these forms):
 
-| Field | Value |
-| ----- | ----- |
-| Client ID | A stable id your frontend will use; generate a UUID |
-| Secret | Empty. A browser app cannot keep a secret; PKCE replaces it |
-| Confidential | Off |
-| PKCE | On |
-| Scopes | The scope you created, set as the consumer's default |
-| Redirect URI | `https://your-frontend/callback`, one per environment |
+| Field        | Value                                                       |
+| ------------ | ----------------------------------------------------------- |
+| Client ID    | A stable id your frontend will use; generate a UUID         |
+| Secret       | Empty. A browser app cannot keep a secret; PKCE replaces it |
+| Confidential | Off                                                         |
+| PKCE         | On                                                          |
+| Scopes       | The scope you created, set as the consumer's default        |
+| Redirect URI | `https://your-frontend/callback`, one per environment       |
 
 Every frontend origin that logs in needs its redirect URI registered;
 the origins people forget are previews and `http://localhost:3000`.
@@ -81,10 +81,8 @@ it registers server middleware that `nuxt start` only loads from
 
 ```js
 export default {
-  modules: [
-    ['druxt-auth', { clientId: process.env.OAUTH_CLIENT_ID }],
-  ],
-}
+  modules: [['druxt-auth', { clientId: process.env.OAUTH_CLIENT_ID }]],
+};
 ```
 
 No `scope` option is needed. When the app sends none, Drupal applies
@@ -99,7 +97,7 @@ PKCE flow above, the right default) and `drupal-password` (server-side
 password grant). Trigger a login from any component:
 
 ```js
-this.$auth.loginWith('drupal-authorization_code')
+this.$auth.loginWith('drupal-authorization_code');
 ```
 
 The `/callback` route is handled for you.

--- a/docs/nuxt/content/how-to/deploy-server.md
+++ b/docs/nuxt/content/how-to/deploy-server.md
@@ -34,6 +34,9 @@ server {
   listen 443 ssl http2;
   server_name www.example.com;
 
+  ssl_certificate /etc/ssl/certs/www.example.com.pem;
+  ssl_certificate_key /etc/ssl/private/www.example.com.key;
+
   location / {
     proxy_pass http://127.0.0.1:3000;
     proxy_set_header Host $host;

--- a/docs/nuxt/content/how-to/deploy-server.md
+++ b/docs/nuxt/content/how-to/deploy-server.md
@@ -62,6 +62,8 @@ location / {
 
 location @node {
   proxy_pass http://127.0.0.1:3000;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
 

--- a/docs/nuxt/content/how-to/deploy-server.md
+++ b/docs/nuxt/content/how-to/deploy-server.md
@@ -81,16 +81,16 @@ an `nginx` service whose image contains the generated files plus a
   (declared as build arguments), not just the running container. This
   is true of any Docker-based platform.
 - The backend must be reachable from the builder. Gate the build on the
-  backend answering (`curl` its `/jsonapi` until 200) and retry the
-  build once or twice; large generates can fail transiently.
+  backend answering (`curl` its `/jsonapi` until 200), and retry the
+  build once or twice, because large generates can fail transiently.
 
 ## Content freshness
 
 Server-rendered pages are live. Generated pages in the hybrid are not:
 rebuild on a schedule, or from a Drupal webhook, whichever matches how
-often editors publish. See [Deploy a
-static site](/how-to/deploy-static#after-the-first-deploy) for the
-rebuild options; they apply to the hybrid's static half unchanged.
+often editors publish. The rebuild options in [Deploy a static
+site](/how-to/deploy-static#after-the-first-deploy) apply to the
+hybrid's static half unchanged.
 
 ## Where to go next
 

--- a/docs/nuxt/content/how-to/deploy-server.md
+++ b/docs/nuxt/content/how-to/deploy-server.md
@@ -1,0 +1,102 @@
+---
+title: Deploy a server-rendered site
+weight: 4
+description: 'Run the built app as a node service behind a web server, on your own host or a container platform like Lagoon.'
+---
+
+> **Before you start:** read [Deployment
+> models](/explanation/deployment-models) to confirm you need a server.
+> Static hosting is cheaper and simpler when it fits.
+
+A server-rendered Druxt site is a node process:
+
+```sh
+nuxt build
+nuxt start
+```
+
+`nuxt start` reads `HOST` and `PORT` (see [Environment
+variables](/how-to/environment-variables)) and serves live-rendered
+pages. Run it under a supervisor (systemd, PM2, or a container
+platform's own runtime) so it restarts on failure, and put a web server
+or the platform's ingress in front for TLS.
+
+The [API proxy](/how-to/proxy) works in this model, so browsers can talk
+only to the frontend origin, and server middleware can hold secrets
+(mail delivery, search services) via `privateRuntimeConfig`.
+
+## Behind nginx
+
+A minimal reverse proxy:
+
+```nginx
+server {
+  listen 443 ssl http2;
+  server_name www.example.com;
+
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+```
+
+Add caching for anonymous traffic once things work. One caution from
+production: anything that sets cookies on every response (some auth
+setups do) makes responses uncacheable; keep anonymous responses
+cookie-free so a CDN or cache in front can do its job.
+
+## The hybrid: static files with a server fallback
+
+Production Druxt sites often combine the models: nginx serves the
+`nuxt generate` output directly with long cache headers, and passes
+anything not generated (authenticated pages, server routes) to the node
+service:
+
+```nginx
+location / {
+  root /app/dist;
+  try_files $uri $uri/index.html @node;
+}
+
+location @node {
+  proxy_pass http://127.0.0.1:3000;
+}
+```
+
+Most traffic gets CDN-grade static delivery; the node service only works
+for the routes that need it. Driving the build target with an
+environment variable (`NUXT_TARGET`) lets one codebase produce both
+builds.
+
+## On a container platform
+
+On [Lagoon](https://lagoon.sh) (which hosts this site) the same shapes
+map to services: a `node` service running `nuxt start`, or the hybrid as
+an `nginx` service whose image contains the generated files plus a
+`node` fallback service. The build runs in the image build, which means:
+
+- Environment variables the build needs must reach the **image build**
+  (declared as build arguments), not just the running container. This
+  is true of any Docker-based platform.
+- The backend must be reachable from the builder. Gate the build on the
+  backend answering (`curl` its `/jsonapi` until 200) and retry the
+  build once or twice; large generates can fail transiently.
+
+## Content freshness
+
+Server-rendered pages are live. Generated pages in the hybrid are not:
+rebuild on a schedule, or from a Drupal webhook, whichever matches how
+often editors publish. See [Deploy a
+static site](/how-to/deploy-static#after-the-first-deploy) for the
+rebuild options; they apply to the hybrid's static half unchanged.
+
+## Where to go next
+
+- [Environment variables](/how-to/environment-variables): the build-time
+  vs runtime distinction matters most in this model.
+- [Proxy the Drupal backend](/how-to/proxy): single-origin browser
+  traffic.
+- [Authenticate users with OAuth](/how-to/authentication): server
+  deployments unlock the full authenticated experience.

--- a/docs/nuxt/content/how-to/environment-variables.md
+++ b/docs/nuxt/content/how-to/environment-variables.md
@@ -1,6 +1,6 @@
 ---
 title: Environment variables
-weight: 5
+weight: 6
 description: 'Every variable a Druxt build reads, where it comes from, and the build-time vs runtime distinction that catches people out.'
 ---
 

--- a/docs/nuxt/content/how-to/troubleshooting.md
+++ b/docs/nuxt/content/how-to/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshoot common issues
-weight: 2
+weight: 7
 description: Quick answers to the problems reported most often by real users, from the missing Vue template box to site-wide JSON:API 403 failures.
 ---
 

--- a/docs/nuxt/content/how-to/troubleshooting.md
+++ b/docs/nuxt/content/how-to/troubleshooting.md
@@ -95,8 +95,9 @@ backend](/how-to/prepare-the-backend).
 ## "require() of ES Module axios" crash on a fresh install
 
 Nuxt 2's webpack 4 resolves newer axios releases through their ESM
-entry, which the server, built as CommonJS, cannot load. Pin axios to a 0.x
-release, or transpile it in `nuxt.config.js`:
+entry, which the server, built as CommonJS, cannot load. Pin axios to a
+0.x release (the [compatibility table](/modules/druxt) lists the known
+pins), or transpile it in `nuxt.config.js`:
 
 ```js
 export default {

--- a/docs/nuxt/content/tutorials/README.md
+++ b/docs/nuxt/content/tutorials/README.md
@@ -17,8 +17,8 @@ lesson.
   `DruxtModule` to create your own Druxt-powered components.
 - [Add a login flow](/tutorials/authentication): turn the quickstart's
   already-configured OAuth setup into a real, working login.
-- [Deploy your site](/tutorials/deploy-your-site): take the quickstart
-  from localhost to a live URL on a free static host.
+- [Deploy your site](/tutorials/deploy-your-site): generate the
+  quickstart as static files and put a working Druxt site on a live URL.
 
 If you already have a site running and want to accomplish a specific task,
 see the [How-to guides](/how-to). To understand _why_ Druxt works the way it

--- a/docs/nuxt/content/tutorials/authentication.md
+++ b/docs/nuxt/content/tutorials/authentication.md
@@ -115,6 +115,6 @@ rather than requiring people to know the `/user/login` URL by heart.
 - See this flow put to work in a real app: [Explore the example
   apps](/how-to/example-apps): Content Ops Console uses this exact login to
   authenticate its inline content editing.
-- Full authentication option reference (password grant, scopes, environment
-  variables): the [`druxt-auth` README](https://github.com/druxt/druxt-auth).
+- Full authentication option reference (scopes, environment variables):
+  the [`druxt-auth` README](https://github.com/druxt/druxt-auth).
 - Understand the machine you just started: [Architecture](/explanation/architecture).

--- a/packages/druxt/README.md
+++ b/packages/druxt/README.md
@@ -44,6 +44,22 @@ on. It provides the three pieces the whole framework shares:
    [Troubleshooting](https://druxtjs.org/how-to/troubleshooting)
    if requests are failing after install.
 
+## Compatibility
+
+As of September 2026:
+
+| | Supported |
+| --- | --- |
+| Nuxt | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported; it is the next major's target. |
+| Vue | 2.7 |
+| Node | 16 recommended; 14 works. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build. |
+| Drupal core | 8.8 through 11 |
+| Drupal module | `drupal/druxt` ^1.2, which brings `decoupled_router` ^2.0, `jsonapi_menu_items` and `jsonapi_views` |
+| Known pins | `@nuxtjs/storybook` 4.2.0 (later majors need Nuxt 3); axios 0.x, or add it to `build.transpile` |
+
+Translated routes additionally need a `decoupled_router` patch; see the
+[multilingual guide](https://druxtjs.org/how-to/multilingual).
+
 ## Settings
 
 | Option        | Type              | Default     | Description                                                              |

--- a/packages/druxt/README.md
+++ b/packages/druxt/README.md
@@ -46,15 +46,16 @@ on. It provides the three pieces the whole framework shares:
 
 ## Compatibility
 
-As of September 2026:
+As of September 2026. Current release: druxt 0.24.0, published November
+2023.
 
 | | Supported |
 | --- | --- |
-| Nuxt | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported; it is the next major's target. |
+| Nuxt | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported. |
 | Vue | 2.7 |
-| Node | 16 recommended; 14 works. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build. |
-| Drupal core | 8.8 through 11 |
-| Drupal module | `drupal/druxt` ^1.2, which brings `decoupled_router` ^2.0, `jsonapi_menu_items` and `jsonapi_views` |
+| Node | 16, the tested version. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build. |
+| Drupal core | 10.1 through 11 in practice: the module accepts 8.8+, but its Decoupled Router 2.x dependency requires 10.1. Tested against 10 and 11. |
+| Drupal module | `drupal/druxt` ^1.2, which brings `decoupled_router`, `jsonapi_menu_items` and `jsonapi_views`. Hold `decoupled_router` below 2.0.7 ([#3618675](https://www.drupal.org/i/3618675)). |
 | Known pins | `@nuxtjs/storybook` 4.2.0 (later majors need Nuxt 3); axios 0.x, or add it to `build.transpile` |
 
 Translated routes additionally need a `decoupled_router` patch; see the
@@ -65,7 +66,7 @@ Translated routes additionally need a `decoupled_router` patch; see the
 | Option        | Type              | Default     | Description                                                              |
 | ------------- | ----------------- | ----------- | ------------------------------------------------------------------------ |
 | `baseUrl`     | `string`          |             | The Drupal backend URL. **Required.**                                    |
-| `endpoint`    | `string`          | `'jsonapi'` | The JSON:API endpoint path.                                              |
+| `endpoint`    | `string`          | `'/jsonapi'` | The JSON:API endpoint path.                                             |
 | `proxy.api`   | `boolean`         | `false`     | Proxy API requests via Nuxt ([guide](https://druxtjs.org/how-to/proxy)). |
 | `proxy.files` | `boolean\|string` | `false`     | Proxy Drupal files. A string sets the site.                              |
 

--- a/packages/druxt/README.md
+++ b/packages/druxt/README.md
@@ -46,29 +46,28 @@ on. It provides the three pieces the whole framework shares:
 
 ## Compatibility
 
-As of September 2026. Current release: druxt 0.24.0, published November
-2023.
+As of September 2026. Current release: druxt 0.24.0, published November 2023.
 
-| | Supported |
-| --- | --- |
-| Nuxt | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported. |
-| Vue | 2.7 |
-| Node | 16, the tested version. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build. |
-| Drupal core | 10.1 through 11 in practice: the module accepts 8.8+, but its Decoupled Router 2.x dependency requires 10.1. Tested against 10 and 11. |
+|               | Supported                                                                                                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Nuxt          | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported.                                                                                                                               |
+| Vue           | 2.7                                                                                                                                                                                 |
+| Node          | 16, the tested version. Node 16 is past upstream end of life; the 1.x line targets it deliberately. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build.            |
+| Drupal core   | 10.1 through 11 in practice: the module accepts 8.8+, but its Decoupled Router 2.x dependency requires 10.1. Tested against 10 and 11.                                              |
 | Drupal module | `drupal/druxt` ^1.2, which brings `decoupled_router`, `jsonapi_menu_items` and `jsonapi_views`. Hold `decoupled_router` below 2.0.7 ([#3618675](https://www.drupal.org/i/3618675)). |
-| Known pins | `@nuxtjs/storybook` 4.2.0 (later majors need Nuxt 3); axios 0.x, or add it to `build.transpile` |
+| Known pins    | `@nuxtjs/storybook` 4.2.0 (later majors need Nuxt 3); axios 0.x, or add it to `build.transpile`                                                                                     |
 
 Translated routes additionally need a `decoupled_router` patch; see the
 [multilingual guide](https://druxtjs.org/how-to/multilingual).
 
 ## Settings
 
-| Option        | Type              | Default     | Description                                                              |
-| ------------- | ----------------- | ----------- | ------------------------------------------------------------------------ |
-| `baseUrl`     | `string`          |             | The Drupal backend URL. **Required.**                                    |
-| `endpoint`    | `string`          | `'/jsonapi'` | The JSON:API endpoint path.                                             |
-| `proxy.api`   | `boolean`         | `false`     | Proxy API requests via Nuxt ([guide](https://druxtjs.org/how-to/proxy)). |
-| `proxy.files` | `boolean\|string` | `false`     | Proxy Drupal files. A string sets the site.                              |
+| Option        | Type              | Default      | Description                                                              |
+| ------------- | ----------------- | ------------ | ------------------------------------------------------------------------ |
+| `baseUrl`     | `string`          |              | The Drupal backend URL. **Required.**                                    |
+| `endpoint`    | `string`          | `'/jsonapi'` | The JSON:API endpoint path.                                              |
+| `proxy.api`   | `boolean`         | `false`      | Proxy API requests via Nuxt ([guide](https://druxtjs.org/how-to/proxy)). |
+| `proxy.files` | `boolean\|string` | `false`      | Proxy Drupal files. A string sets the site.                              |
 
 See the [Nuxt module API](https://druxtjs.org/api/packages/druxt/nuxt) for the full
 options list.


### PR DESCRIPTION
Wave 3 of the docs programme, stacked on #801.

- Authenticate users with OAuth how-to: the full Simple OAuth setup from scratch, both sides
- Deploy a server-rendered site how-to: the node service behind nginx, and the hybrid
- Compatibility matrix in the druxt package README, mirrored to the module page
- Round-4 review and vale fixes for the pages this wave owns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guides for deploying server-rendered sites and configuring OAuth 2 authentication.
  - Expanded deployment documentation with reverse-proxy, hybrid hosting, container, and content-freshness guidance.
  - Updated how-to, tutorial, and concept descriptions for clearer task-oriented guidance.
  - Added compatibility information and clarified the Druxt endpoint default.
  - Improved troubleshooting guidance with a link to compatible Axios versions.
  - Reordered several documentation pages in navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->