### PR TITLE
docs(explanation): bridge pages for each side of the stack

### DIFF
--- a/docs/nuxt/content/explanation/README.md
+++ b/docs/nuxt/content/explanation/README.md
@@ -25,3 +25,7 @@ instructions. For doing, see the [How-to guides](/how-to).
   happen where, and why CORS only ever bites in the browser.
 - [Deployment models](/explanation/deployment-models): three production
   shapes and the decision framework between them.
+- [Drupal for Nuxt developers](/explanation/drupal-for-nuxt-developers):
+  the backend vocabulary and tooling, in frontend terms.
+- [Nuxt for Drupal developers](/explanation/nuxt-for-drupal-developers):
+  the frontend concepts, mapped to the Drupal ideas they replace.

--- a/docs/nuxt/content/explanation/drupal-for-nuxt-developers.md
+++ b/docs/nuxt/content/explanation/drupal-for-nuxt-developers.md
@@ -1,0 +1,106 @@
+---
+title: Drupal for Nuxt developers
+weight: -8
+description: 'The Drupal vocabulary, tools and commands the rest of these docs assume, explained for developers coming from the JavaScript side.'
+---
+
+Druxt puts a Nuxt frontend on a Drupal backend, so building a Druxt site
+means running Drupal and its tooling without being a Drupal developer.
+This page covers the concepts and commands the rest of these docs use, in
+frontend terms. If you come from Drupal instead, read
+[Nuxt for Drupal developers](/explanation/nuxt-for-drupal-developers).
+
+## What Drupal does in a Druxt project
+
+Drupal is the content backend. Editors create and structure content in its
+admin UI, and Druxt reads that content over
+[JSON:API](https://www.drupal.org/docs/core-modules-and-themes/core-modules/jsonapi-module),
+a REST API included in Drupal core. You will configure Drupal and run its
+CLI, but you will not write PHP: Druxt replaces the layer a Drupal
+developer would normally build.
+
+## The vocabulary
+
+The terms these docs use, and the closest frontend concept for each:
+
+| Drupal term           | What it is                                                                                 | Closest frontend concept                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Entity                | Any piece of stored content or configuration                                               | A record, or a typed object                                                    |
+| Node                  | A content entity, such as a page or an article                                             | A CMS "post"                                                                   |
+| Content type (bundle) | A node's type, defining its fields                                                         | A schema or interface                                                          |
+| Field                 | One property on a content type                                                             | A typed property                                                               |
+| Display mode          | A stored choice of which fields render, and how                                            | A view model; Druxt turns these into [component schemas](/explanation/schemas) |
+| Block                 | A reusable fragment placed in a region of the page                                         | A component instance in a layout slot                                          |
+| Menu                  | An editable navigation tree                                                                | Navigation data, editor-owned                                                  |
+| View                  | A configurable content query with its own display                                          | A saved query plus its list component                                          |
+| Module                | An installable extension (the [Druxt module](https://www.drupal.org/project/druxt) is one) | An npm package or Nuxt module                                                  |
+| Permission            | A grant checked per role, per operation                                                    | Route/API authorization                                                        |
+
+The one that matters most to Druxt is the display mode: Druxt reads
+display modes as schemas and resolves Vue components from them, so a
+change an editor makes in the Drupal admin UI changes what the frontend
+renders. [The schema system](/explanation/schemas) explains this end to
+end.
+
+## Composer
+
+[Composer](https://getcomposer.org) is PHP's npm. `composer.json` plays
+the role of `package.json`, `composer.lock` the role of the lock file, and
+`composer require drupal/druxt` the role of `npm install druxt`. Drupal
+modules install with Composer and are then **enabled** in Drupal: install
+puts the code on disk, enable turns it on for the site. That second step
+has no npm equivalent, and forgetting it is a common early stumble.
+
+## drush, Drupal's CLI
+
+[drush](https://www.drush.org) is Drupal's command-line tool, installed
+per project with `composer require drush/drush`, the way a JS project
+carries its own CLI in `devDependencies`. When the backend runs in a
+container, prefix the command: `ddev drush ...` under
+[DDEV](https://ddev.readthedocs.io).
+
+The commands these docs use:
+
+| Command                                     | What it does                                               |
+| ------------------------------------------- | ---------------------------------------------------------- |
+| `drush pm:enable <module> -y`               | Enables an installed module                                |
+| `drush role:perm:add <role> '<permission>'` | Grants a permission to a role                              |
+| `drush cache:rebuild`                       | Rebuilds Drupal's caches, needed after config file changes |
+| `drush config:set <name> <key> <value>`     | Sets one configuration value                               |
+| `drush user:login` (`uli`)                  | Prints a one-time admin login link                         |
+
+`drush cache:rebuild` earns special mention: Drupal caches aggressively,
+and a config edit that "did nothing" usually just has not been picked up
+yet. It is the Drupal reflex equivalent to restarting the dev server.
+
+## Where configuration lives
+
+Drupal configuration is split between the database and files:
+
+- Most configuration is edited in the admin UI and stored in the
+  database. It can be exported to YAML for version control.
+- `sites/default/settings.php` holds per-environment settings, like
+  `$settings` overrides and the database connection.
+- `sites/default/services.yml` holds container-level settings,
+  including CORS. See
+  [Configure CORS in Drupal](/how-to/configure-cors).
+
+There is no `nuxt.config.js` equivalent here: expect settings spread
+over more than one place.
+
+## What you can skip
+
+Drupal's own rendering stack, Twig templates, the theme layer and render
+arrays: Druxt replaces all of it with Vue, and a standard Druxt site
+never touches Drupal's routing or form APIs either. If a Drupal tutorial
+spends its time in `.theme` files and Twig, it is solving a problem Druxt
+has already taken off your plate.
+
+## Where to go next
+
+- [Prepare the Drupal backend](/how-to/prepare-the-backend): the setup
+  these concepts feed into.
+- [The schema system](/explanation/schemas): display modes as the
+  contract between editors and components.
+- [Getting started](/tutorials/getting-started): a working site without
+  installing Drupal by hand.

--- a/docs/nuxt/content/explanation/drupal-for-nuxt-developers.md
+++ b/docs/nuxt/content/explanation/drupal-for-nuxt-developers.md
@@ -91,8 +91,10 @@ over more than one place.
 ## What you can skip
 
 Drupal's own rendering stack, Twig templates, the theme layer and render
-arrays: Druxt replaces all of it with Vue, and a standard Druxt site
-never touches Drupal's routing or form APIs either. If a Drupal tutorial
+arrays: Druxt replaces all of it with Vue, and you never write code
+against Drupal's routing or form APIs either. Drupal itself keeps
+owning paths and aliases; the frontend resolves them through the
+decoupled router, which is backend configuration, not code you write. If a Drupal tutorial
 spends its time in `.theme` files and Twig, it is solving a problem Druxt
 has already taken off your plate.
 

--- a/docs/nuxt/content/explanation/nuxt-for-drupal-developers.md
+++ b/docs/nuxt/content/explanation/nuxt-for-drupal-developers.md
@@ -1,0 +1,88 @@
+---
+title: Nuxt for Drupal developers
+weight: -8
+description: 'The Nuxt and Vue concepts behind a Druxt frontend, mapped to the Drupal ideas they replace.'
+---
+
+Druxt's frontend is a [Nuxt](https://v2.nuxt.com) application, so building
+a Druxt site means working in JavaScript tooling that has no Drupal
+equivalent installed. This page maps the Nuxt and Vue concepts these docs
+use onto the Drupal ideas they replace. If you come from the JavaScript
+side instead, read
+[Drupal for Nuxt developers](/explanation/drupal-for-nuxt-developers).
+
+## What Nuxt does in a Druxt project
+
+Nuxt is a framework built on [Vue](https://v2.vuejs.org), and it owns
+everything a Drupal theme would: markup, styling, navigation and the
+request/render lifecycle. Druxt targets **Nuxt 2** (and Vue 2); check the
+[compatibility table](/modules/druxt) before reaching for newer
+releases. Instead of PHP rendering Twig on each request, Nuxt renders Vue
+components on a node server, or ahead of time into static files, and then
+**hydrates** in the browser: the JavaScript takes over the rendered page
+and makes it interactive. [Request
+topology](/explanation/request-topology) covers what runs where.
+
+## The mapping
+
+| Drupal idea                       | Nuxt/Vue counterpart               | Notes                                                                    |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| Twig template                     | Vue component                      | Markup, logic and styling in one `.vue` file                             |
+| Theme hook suggestions            | Druxt component suggestions        | The deliberate twin; see below                                           |
+| Region                            | Layout with `<slot>` or `<nuxt />` | Layouts wrap pages the way `page.html.twig` wraps content                |
+| Module                            | Nuxt module or plugin              | Configured in `nuxt.config.js`                                           |
+| `settings.php`                    | `nuxt.config.js`                   | One file, JavaScript, in version control                                 |
+| Composer                          | npm (or yarn)                      | `package.json` is `composer.json`, `npm install` restores the tree       |
+| drush                             | npm scripts                        | `npm run dev`, `npm run generate` and friends, defined per project       |
+| Cache rebuild                     | Restart the dev server, or rebuild | Config changes need a restart; content changes do not                    |
+| Routing (hook_menu, path aliases) | The Druxt wildcard route           | Drupal keeps owning paths; see [Decoupled routing](/explanation/routing) |
+
+## The part that will feel familiar
+
+Druxt's theming system is modeled on Drupal's template suggestions. Where
+Drupal looks for `node--article--teaser.html.twig` before falling back to
+`node.html.twig`, Druxt looks for `DruxtEntityNodeArticleTeaser.vue`
+before `DruxtEntityNodeArticle.vue` and so on down to the default. You
+override rendering by dropping a more specific component into
+`components/`, exactly the reflex you have from theming.
+[Component resolution](/explanation/component-resolution) shows the full
+lookup order, and [Theme Druxt components](/how-to/theming) is the
+hands-on guide.
+
+## The Vue you actually need
+
+A `.vue` file has three sections: `<template>` (the markup, with
+`{{ variable }}` interpolation much like Twig), `<script>` (the
+component's data and behavior) and `<style>`. Data flows into components
+through **props**, roughly the variables a preprocess function hands a
+template. Named **slots** are insertion points a wrapper exposes, the
+concept behind Druxt's themeable wrappers. The examples in these docs
+use nothing beyond those three ideas. Deeper Vue can wait until you
+need it.
+
+## Files that matter
+
+| File             | Role                                                                     |
+| ---------------- | ------------------------------------------------------------------------ |
+| `nuxt.config.js` | All frontend configuration, including every Druxt module's options       |
+| `package.json`   | Dependencies and the `npm run` scripts                                   |
+| `components/`    | Your overrides; anything here is auto-discovered                         |
+| `pages/`         | File-based routing; mostly empty in Druxt, the wildcard route handles it |
+| `static/`        | Files served as-is, like a document root                                 |
+
+## What you can skip
+
+Vuex internals (the [DruxtStore](/explanation/druxt-store) manages state
+for you), webpack configuration (Nuxt owns it) and hand-written REST
+calls (the DruxtClient makes them). You keep working in the Drupal admin
+UI for content modeling; the frontend reads your display modes through
+[the schema system](/explanation/schemas).
+
+## Where to go next
+
+- [Getting started](/tutorials/getting-started): a running site, then
+  poke at it.
+- [Theme Druxt components](/how-to/theming): the suggestion system in
+  practice.
+- [Architecture](/explanation/architecture): the full request lifecycle
+  in one page.

--- a/docs/nuxt/content/explanation/nuxt-for-drupal-developers.md
+++ b/docs/nuxt/content/explanation/nuxt-for-drupal-developers.md
@@ -18,24 +18,24 @@ everything a Drupal theme would: markup, styling, navigation and the
 request/render lifecycle. Druxt targets **Nuxt 2** (and Vue 2); check the
 [compatibility table](/modules/druxt) before reaching for newer
 releases. Instead of PHP rendering Twig on each request, Nuxt renders Vue
-components on a node server, or ahead of time into static files, and then
+components on a Node.js server, or ahead of time into static files, and then
 **hydrates** in the browser: the JavaScript takes over the rendered page
 and makes it interactive. [Request
 topology](/explanation/request-topology) covers what runs where.
 
 ## The mapping
 
-| Drupal idea                       | Nuxt/Vue counterpart               | Notes                                                                    |
-| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| Twig template                     | Vue component                      | Markup, logic and styling in one `.vue` file                             |
-| Theme hook suggestions            | Druxt component suggestions        | The deliberate twin; see below                                           |
-| Region                            | Layout with `<slot>` or `<nuxt />` | Layouts wrap pages the way `page.html.twig` wraps content                |
-| Module                            | Nuxt module or plugin              | Configured in `nuxt.config.js`                                           |
-| `settings.php`                    | `nuxt.config.js`                   | One file, JavaScript, in version control                                 |
-| Composer                          | npm (or yarn)                      | `package.json` is `composer.json`, `npm install` restores the tree       |
-| drush                             | npm scripts                        | `npm run dev`, `npm run generate` and friends, defined per project       |
-| Cache rebuild                     | Restart the dev server, or rebuild | Config changes need a restart; content changes do not                    |
-| Routing (hook_menu, path aliases) | The Druxt wildcard route           | Drupal keeps owning paths; see [Decoupled routing](/explanation/routing) |
+| Drupal idea                             | Nuxt/Vue counterpart               | Notes                                                                    |
+| --------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| Twig template                           | Vue component                      | Markup, logic and styling in one `.vue` file                             |
+| Theme hook suggestions                  | Druxt component suggestions        | The deliberate twin; see below                                           |
+| Region                                  | Layout with `<slot>` or `<nuxt />` | Layouts wrap pages the way `page.html.twig` wraps content                |
+| Module                                  | Nuxt module or plugin              | Configured in `nuxt.config.js`                                           |
+| `settings.php`                          | `nuxt.config.js`                   | One file, JavaScript, in version control                                 |
+| Composer                                | npm (or yarn)                      | `package.json` is `composer.json`, `npm install` restores the tree       |
+| drush                                   | npm scripts                        | `npm run dev`, `npm run generate` and friends, defined per project       |
+| Cache rebuild                           | Restart the dev server, or rebuild | Config changes need a restart; content changes do not                    |
+| Routing (`*.routing.yml`, path aliases) | The Druxt wildcard route           | Drupal keeps owning paths; see [Decoupled routing](/explanation/routing) |
 
 ## The part that will feel familiar
 

--- a/docs/nuxt/content/explanation/nuxt-for-drupal-developers.md
+++ b/docs/nuxt/content/explanation/nuxt-for-drupal-developers.md
@@ -25,17 +25,17 @@ topology](/explanation/request-topology) covers what runs where.
 
 ## The mapping
 
-| Drupal idea                             | Nuxt/Vue counterpart               | Notes                                                                    |
-| --------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| Twig template                           | Vue component                      | Markup, logic and styling in one `.vue` file                             |
-| Theme hook suggestions                  | Druxt component suggestions        | The deliberate twin; see below                                           |
-| Region                                  | Layout with `<slot>` or `<nuxt />` | Layouts wrap pages the way `page.html.twig` wraps content                |
-| Module                                  | Nuxt module or plugin              | Configured in `nuxt.config.js`                                           |
-| `settings.php`                          | `nuxt.config.js`                   | One file, JavaScript, in version control                                 |
-| Composer                                | npm (or yarn)                      | `package.json` is `composer.json`, `npm install` restores the tree       |
-| drush                                   | npm scripts                        | `npm run dev`, `npm run generate` and friends, defined per project       |
-| Cache rebuild                           | Restart the dev server, or rebuild | Config changes need a restart; content changes do not                    |
-| Routing (`*.routing.yml`, path aliases) | The Druxt wildcard route           | Drupal keeps owning paths; see [Decoupled routing](/explanation/routing) |
+| Drupal idea                             | Nuxt/Vue counterpart               | Notes                                                                                                                                     |
+| --------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Twig template                           | Vue component                      | Markup, logic and styling in one `.vue` file                                                                                              |
+| Theme hook suggestions                  | Druxt component suggestions        | The deliberate twin; see below                                                                                                            |
+| Region                                  | Layout with `<slot>` or `<nuxt />` | Layouts wrap pages the way `page.html.twig` wraps content                                                                                 |
+| Module                                  | Nuxt module or plugin              | Configured in `nuxt.config.js`                                                                                                            |
+| `settings.php`                          | `nuxt.config.js`                   | One file, JavaScript, in version control                                                                                                  |
+| Composer                                | npm (or yarn)                      | `package.json` is `composer.json`, `npm install` restores the tree                                                                        |
+| drush                                   | npm scripts                        | `npm run dev`, `npm run generate` and friends, defined per project                                                                        |
+| Cache rebuild                           | Restart the dev server, or rebuild | Config changes need a restart. Content is live in dev and SSR; a generated static build embeds it, so content changes need a regeneration |
+| Routing (`*.routing.yml`, path aliases) | The Druxt wildcard route           | Drupal keeps owning paths; see [Decoupled routing](/explanation/routing)                                                                  |
 
 ## The part that will feel familiar
 
@@ -51,7 +51,7 @@ hands-on guide.
 
 ## The Vue you actually need
 
-A `.vue` file has three sections: `<template>` (the markup, with
+A `.vue` file can hold three sections, each optional: `<template>` (the markup, with
 `{{ variable }}` interpolation much like Twig), `<script>` (the
 component's data and behavior) and `<style>`. Data flows into components
 through **props**, roughly the variables a preprocess function hands a

--- a/docs/nuxt/content/how-to/authentication.md
+++ b/docs/nuxt/content/how-to/authentication.md
@@ -10,7 +10,9 @@ description: 'The full OAuth setup from scratch: Simple OAuth keys, scopes and a
 > backend. Drupal-side commands run in the Drupal project root, with
 > [drush](https://www.drush.org) installed
 > (`composer require drush/drush`); if the backend runs in a container,
-> prefix them with your tool's exec command.
+> prefix them with your tool's exec command. New to the Drupal side?
+> Start with
+> [Drupal for Nuxt developers](/explanation/drupal-for-nuxt-developers).
 
 Druxt authenticates with OAuth 2 Authorization Code + PKCE:
 [Simple OAuth](https://www.drupal.org/project/simple_oauth) on the Drupal

--- a/docs/nuxt/content/how-to/prepare-the-backend.md
+++ b/docs/nuxt/content/how-to/prepare-the-backend.md
@@ -14,7 +14,10 @@ Commands run in the Drupal project root. `composer` manages Drupal
 dependencies; [drush](https://www.drush.org) is Drupal's CLI, installed
 into the project with `composer require drush/drush`. If the backend
 runs in a container, prefix commands with your tool's exec command.
-Every step also has an admin-UI path, noted as it appears.
+Every step also has an admin-UI path, noted as it appears. If Drupal and
+its tooling are new to you,
+[Drupal for Nuxt developers](/explanation/drupal-for-nuxt-developers)
+explains the concepts these steps lean on.
 
 ## Install the Druxt module
 

--- a/docs/nuxt/content/tutorials/getting-started.md
+++ b/docs/nuxt/content/tutorials/getting-started.md
@@ -15,7 +15,10 @@ You'll use:
 - **The one-command setup**: provisions a local throwaway Drupal (SQLite)
   with Druxt and OAuth pre-configured.
 
-No prior Druxt knowledge is assumed.
+No prior Druxt knowledge is assumed. If one half of the stack is new to
+you, [Drupal for Nuxt developers](/explanation/drupal-for-nuxt-developers)
+and [Nuxt for Drupal developers](/explanation/nuxt-for-drupal-developers)
+fill in the other side's vocabulary. This tutorial works without them.
 
 ## Prerequisites
 


### PR DESCRIPTION
Wave 5 of the docs programme, stacked on #803.

- Drupal for Nuxt developers: the backend vocabulary, Composer and drush, in frontend terms
- Nuxt for Drupal developers: the frontend concepts mapped to the Drupal ideas they replace
- Cross-linked from getting started, prepare the backend and the authentication cookbook
- Prose enhancements (copy button, figures, tables) applied to every content section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance introducing Drupal concepts, tools, terminology, and workflows for Nuxt developers.
  - Added guidance explaining Nuxt and Vue concepts for Drupal developers, including component theming and key project files.
  - Updated the documentation index and linked the new guides from authentication, backend preparation, and getting-started content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->