### PR TITLE
feat(docs): apply the design spec to diagrams, tables, code blocks and figures

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -163,6 +163,7 @@ themable
 toggleable
 topbar
 trixie
+tspan
 umami
 uncacheable
 unjs

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -75,6 +75,7 @@ jsonapi
 Knip
 knip
 Ksection
+labelledby
 langcode
 libfreetype
 libicu

--- a/docs/nuxt/assets/css/app.css
+++ b/docs/nuxt/assets/css/app.css
@@ -59,23 +59,6 @@ html {
   }
 }
 
-/* The code-copy button is `opacity-0` until its `pre` is hovered, which left
-   it permanently invisible to keyboard users — still in the tab order, still
-   focusable, never shown (WCAG 2.4.7). A `focus:opacity-100` utility did not
-   take effect here, so this states it explicitly rather than depending on
-   JIT variant generation. Scoped to the button AppProse injects. */
-.prose pre button:focus,
-.prose pre button:focus-visible {
-  opacity: 1;
-}
-
-/* Touch devices have no hover, so the hover-revealed button never appears. */
-@media (hover: none) {
-  .prose pre button {
-    opacity: 1;
-  }
-}
-
 /* Filled brand buttons.
    `primary` (#53b0eb) and `secondary` (#41b883) are the brand tints and are
    used, correctly, for borders, badges, radios and icons. They are simply too
@@ -139,9 +122,10 @@ html {
 }
 
 /* Fenced mermaid diagrams, rendered by plugins/mermaid.client.js.
-   Colours override mermaid's own embedded stylesheet (hence !important)
-   with the daisyUI tokens, so diagrams follow the colour mode with no
-   re-render. */
+   The plugin strips mermaid's embedded styles, so these rules are the
+   only styling; !important still has to beat the presentation attributes
+   and inline font styles mermaid 8 writes on each element. Values are the
+   design spec against the daisyUI tokens, so both themes come from one rule. */
 .docs-diagram {
   margin: 1.5rem 0;
   overflow-x: auto;
@@ -150,31 +134,67 @@ html {
   display: block;
   margin: 0 auto;
   max-width: 100%;
+}
+/* Below 640px a diagram never renders under 70% of its natural size (the
+   floor plugins/mermaid.client.js sets); it scrolls in its container instead. */
+@media (max-width: 639px) {
+  .docs-diagram svg {
+    min-width: var(--docs-diagram-floor, 0);
+  }
+}
+/* Mermaid writes its own font stacks inline on each text element (Open-Sans
+   for actors, Trebuchet for messages), so the site font has to be forced on
+   the text itself, not just the svg. */
+.docs-diagram svg,
+.docs-diagram text,
+.docs-diagram tspan,
+.docs-diagram foreignObject div,
+.docs-diagram foreignObject span {
   font-family: inherit !important;
 }
-.docs-diagram .actor,
+
+/* Nodes and actors share one treatment: identity comes from a solid border
+   and a bold label, not a louder fill. */
+.docs-diagram rect.actor,
 .docs-diagram .node rect,
 .docs-diagram .node polygon,
 .docs-diagram .node circle,
+.docs-diagram .node path,
 .docs-diagram rect.rect {
   fill: hsl(var(--b2)) !important;
-  stroke: hsl(var(--bc) / 0.35) !important;
+  stroke: hsl(var(--b3)) !important;
+  stroke-width: 1px !important;
+  rx: 8;
+  ry: 8;
+}
+.docs-diagram text.actor,
+.docs-diagram .node .label,
+.docs-diagram .node .nodeLabel {
+  fill: hsl(var(--bc)) !important;
+  color: hsl(var(--bc)) !important;
+  font-size: 14px !important;
+  font-weight: 600 !important;
 }
 .docs-diagram .cluster rect {
   fill: hsl(var(--b1)) !important;
-  stroke: hsl(var(--bc) / 0.25) !important;
+  stroke: hsl(var(--bc) / 0.2) !important;
+  stroke-width: 1px !important;
+  rx: 10;
+  ry: 10;
 }
+
 .docs-diagram text,
 .docs-diagram .messageText,
-.docs-diagram .noteText,
 .docs-diagram .labelText,
-.docs-diagram .loopText,
-.docs-diagram .cluster-label text,
-.docs-diagram .titleText {
+.docs-diagram .loopText {
   fill: hsl(var(--bc)) !important;
   stroke: none !important;
 }
-.docs-diagram .node .label,
+.docs-diagram .messageText,
+.docs-diagram .labelText,
+.docs-diagram .loopText {
+  font-size: 14px !important;
+}
 .docs-diagram .edgeLabel,
 .docs-diagram foreignObject div {
   color: hsl(var(--bc)) !important;
@@ -184,45 +204,216 @@ html {
   background-color: hsl(var(--b1)) !important;
   fill: hsl(var(--b1)) !important;
 }
+
+/* Line hierarchy: messages and edges, then lifelines, then frames. */
 .docs-diagram .messageLine0,
 .docs-diagram .messageLine1,
-.docs-diagram .actor-line,
 .docs-diagram .edgePath .path,
-.docs-diagram .flowchart-link,
-.docs-diagram .loopLine {
-  stroke: hsl(var(--bc) / 0.6) !important;
+.docs-diagram .flowchart-link {
+  stroke: hsl(var(--bc) / 0.75) !important;
+  stroke-width: 1.5px !important;
 }
 .docs-diagram .arrowheadPath,
-.docs-diagram marker path {
-  fill: hsl(var(--bc) / 0.6) !important;
+.docs-diagram marker path,
+.docs-diagram marker circle {
+  fill: hsl(var(--bc) / 0.75) !important;
   stroke: none !important;
 }
-.docs-diagram .note {
-  fill: hsl(var(--p) / 0.15) !important;
-  stroke: hsl(var(--p) / 0.6) !important;
+.docs-diagram marker.cross path {
+  fill: none !important;
+  stroke: hsl(var(--bc) / 0.75) !important;
 }
-.docs-diagram .messageText,
-.docs-diagram .noteText,
-.docs-diagram .labelText,
-.docs-diagram .loopText {
-  font-size: 14px !important;
+/* Mermaid 8 writes the actor height into the lifeline's class attribute
+   (class="200"), so lifelines are matched by id. */
+.docs-diagram line[id^="actor"],
+.docs-diagram .actor-line {
+  stroke: hsl(var(--bc) / 0.25) !important;
+  stroke-width: 1px !important;
 }
-.docs-diagram .actor {
-  rx: 6;
+.docs-diagram .loopLine {
+  stroke: hsl(var(--bc) / 0.4) !important;
+  stroke-width: 1px !important;
+}
+.docs-diagram .labelBox {
+  fill: hsl(var(--b2)) !important;
+  stroke: hsl(var(--bc) / 0.4) !important;
+  stroke-width: 1px !important;
 }
 
-/* Prose tables: contain wide tables in their own scroll region, and stop
-   identifiers (env var names, option keys) wrapping mid-token. The global
-   overflow-wrap: anywhere on code is for long URLs in running prose; inside
-   a cell it shredded names like NODE_OPTIONS. */
-.prose table {
+/* Notes read as an aside: a light primary tint, not a warning. */
+.docs-diagram .note {
+  fill: hsl(var(--p) / 0.1) !important;
+  stroke: hsl(var(--p) / 0.35) !important;
+  stroke-width: 1px !important;
+  rx: 4;
+  ry: 4;
+}
+.docs-diagram .noteText {
+  fill: hsl(var(--bc)) !important;
+  font-size: 13px !important;
+}
+
+/* Cluster titles and diagram titles carry the one accent. */
+.docs-diagram .cluster-label text,
+.docs-diagram .cluster-label .nodeLabel,
+.docs-diagram .titleText {
+  fill: hsl(var(--pf)) !important;
+  color: hsl(var(--pf)) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+}
+
+/* Prose tables. AppProse wraps each table in .docs-table > .docs-table-scroll,
+   a scroll region that is only in the tab order while it overflows, and
+   labels body cells with their column heading for the stacked layout. */
+.prose .docs-table {
+  position: relative;
+  margin: 2em 0;
+}
+.prose .docs-table-scroll {
+  overflow-x: auto;
+}
+.prose .docs-table table {
+  margin: 0;
+}
+/* Until AppProse wraps it (or without JavaScript) a wide table scrolls itself. */
+.prose table:not([data-enhanced]) {
   display: block;
   width: max-content;
   max-width: 100%;
   overflow-x: auto;
 }
+/* Identifiers (env var names, option keys) stay on one line. The global
+   overflow-wrap: anywhere on code is for long URLs in running prose; inside
+   a cell it shredded names like NODE_OPTIONS. */
 .prose table code,
 .prose thead th {
   white-space: nowrap;
   overflow-wrap: normal;
+}
+.prose thead {
+  border-bottom: 0;
+}
+.prose thead th {
+  color: hsl(var(--bc));
+  font-weight: 600;
+  padding: 10px 16px;
+  border-bottom: 1px solid hsl(var(--bc) / 0.4);
+  vertical-align: top;
+}
+.prose tbody td {
+  padding: 10px 16px;
+  vertical-align: top;
+}
+.prose thead th:first-child,
+.prose tbody td:first-child {
+  padding-left: 0;
+}
+.prose tbody tr {
+  border-bottom: 1px solid hsl(var(--b3));
+}
+.prose tbody tr:last-child {
+  border-bottom: 0;
+}
+/* Right-edge fade while there is more table to the right. Painted as an
+   overlay, not a scroll shadow: cells are transparent, so a gradient behind
+   them would never show. AppProse toggles data-overflow from the scroller. */
+.prose .docs-table::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 24px;
+  background: linear-gradient(to right, hsl(var(--b1) / 0), hsl(var(--b1)));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms;
+}
+.prose .docs-table[data-overflow]::after {
+  opacity: 1;
+}
+@media print {
+  .prose .docs-table::after {
+    display: none;
+  }
+}
+/* Below 640px a table with column headings stacks: each row becomes a block
+   headed by its first cell, and the other cells print their heading above
+   the value. Tables without headings keep scrolling. */
+@media (max-width: 639px) {
+  .prose .docs-table[data-stack] table,
+  .prose .docs-table[data-stack] tbody,
+  .prose .docs-table[data-stack] tr,
+  .prose .docs-table[data-stack] td {
+    display: block;
+  }
+  .prose .docs-table[data-stack] thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .prose .docs-table[data-stack] tr {
+    padding: 14px 0;
+    border-bottom: 1px solid hsl(var(--b3));
+  }
+  .prose .docs-table[data-stack] tr:last-child {
+    border-bottom: 0;
+  }
+  .prose .docs-table[data-stack] td {
+    padding: 0;
+    color: hsl(var(--bc));
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .prose .docs-table[data-stack] td:first-child {
+    font-weight: 600;
+  }
+  .prose .docs-table[data-stack] td + td::before {
+    content: attr(data-label);
+    display: block;
+    margin: 10px 0 3px;
+    color: hsl(var(--bc) / 0.6);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  .prose .docs-table[data-stack] table code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+}
+
+/* Screenshot figures (AppFigure, and the figures AppProse builds around
+   prose images): a hairline frame, a shadow in light only, no browser chrome. */
+.docs-figure-frame {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid hsl(var(--b3));
+  border-radius: 8px;
+  background-color: hsl(var(--b2));
+  box-shadow: 0 1px 3px rgb(15 23 32 / 0.08);
+}
+[data-theme='dark'] .docs-figure-frame {
+  box-shadow: none;
+}
+.docs-figure-frame img {
+  display: block;
+  width: 100%;
+  margin: 0;
+  border-radius: 0;
+}
+.docs-figure figcaption {
+  margin-top: 10px;
+  color: hsl(var(--bc) / 0.7);
+  font-size: 13px;
+  text-align: left;
 }

--- a/docs/nuxt/assets/css/app.css
+++ b/docs/nuxt/assets/css/app.css
@@ -10,8 +10,8 @@
 
 /* The bare `:focus-visible` above is specificity (0,1,0) and loses to daisyUI's
    own `.menu :where(li) > a:focus` and `.btn:focus`, which set a *transparent*
-   outline. Measured before this rule: 13 of 34 tab stops — the whole sidebar
-   nav, the header nav and the colour-mode options — computed
+   outline. Measured before this rule: 13 of 34 tab stops - the whole sidebar
+   nav, the header nav and the colour-mode options - computed
    `outline: rgba(0,0,0,0) solid 2px` with no box-shadow, i.e. no visible focus
    at all in either theme (WCAG 2.4.7). `.btn`'s dark focus ring also measured
    1.04:1 against base-100. !important is deliberate: this is the accessibility
@@ -63,7 +63,7 @@ html {
    `primary` (#53b0eb) and `secondary` (#41b883) are the brand tints and are
    used, correctly, for borders, badges, radios and icons. They are simply too
    light to carry text: white on them measures 2.39:1 and 2.50:1, and the
-   logo's own blue (#3498DB) is no better at 3.15:1 — no text colour works on
+   logo's own blue (#3498DB) is no better at 3.15:1 - no text colour works on
    a tint that pale except near-black, which reads wrong on a blue button.
 
    So the tint stays the brand colour everywhere it is decorative, and only
@@ -101,7 +101,7 @@ html {
 
 /* Search dialog input row.
    The input sits between the search icon and the esc key, so the default
-   focus ring drew a rectangle around the middle child only — visibly inset
+   focus ring drew a rectangle around the middle child only - visibly inset
    inside the row's own border, excluding both siblings. Suppress the ring on
    the input and draw it on the row instead, so the focus indicator matches
    what a user reads as "the search box". */

--- a/docs/nuxt/assets/css/app.css
+++ b/docs/nuxt/assets/css/app.css
@@ -126,20 +126,87 @@ html {
    only styling; !important still has to beat the presentation attributes
    and inline font styles mermaid 8 writes on each element. Values are the
    design spec against the daisyUI tokens, so both themes come from one rule. */
+/* Outranks the typography plugin's figure margin. */
+.prose .docs-diagram,
 .docs-diagram {
   margin: 1.5rem 0;
-  overflow-x: auto;
 }
 .docs-diagram svg {
   display: block;
   margin: 0 auto;
   max-width: 100%;
 }
-/* Below 640px a diagram never renders under 70% of its natural size (the
-   floor plugins/mermaid.client.js sets); it scrolls in its container instead. */
+/* Below 640px a diagram never renders under 85% of its natural size (the
+   floor plugins/mermaid.client.js sets); it scrolls in its frame instead. */
 @media (max-width: 639px) {
   .docs-diagram svg {
     min-width: var(--docs-diagram-floor, 0);
+  }
+}
+/* A diagram is a figure: frame > scroller > svg, then the caption the
+   plugin takes from the source's first %% line. The frame carries the
+   same right-edge fade the tables use while there is more to scroll. */
+.docs-diagram .docs-diagram-frame {
+  position: relative;
+}
+.docs-diagram .docs-diagram-scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.docs-diagram .docs-diagram-scroll:focus-visible {
+  outline: 2px solid hsl(var(--p));
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+.docs-diagram .docs-diagram-frame::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 24px;
+  background: linear-gradient(to right, hsl(var(--b1) / 0), hsl(var(--b1)));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 150ms;
+}
+.docs-diagram .docs-diagram-frame[data-overflow]::after {
+  opacity: 1;
+}
+.docs-diagram figcaption {
+  margin-top: 10px;
+  color: hsl(var(--bc) / 0.7);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: left;
+}
+/* A row of small diagrams (the deployment models): content-sized cards
+   sharing the spare width, captions aligned along the bottom, one column
+   below 640px. Content opts in with <div class="docs-diagram-row">. */
+.docs-diagram-row {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 16px;
+  margin: 1.5rem 0;
+}
+.docs-diagram-row .docs-diagram {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 16px 12px 12px;
+  border: 1px solid hsl(var(--b3));
+  border-radius: 8px;
+}
+.docs-diagram-row .docs-diagram figcaption {
+  margin-top: auto;
+  padding-top: 12px;
+}
+.docs-diagram-row .docs-diagram svg {
+  min-width: 0;
+}
+@media (max-width: 639px) {
+  .docs-diagram-row {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 /* Mermaid writes its own font stacks inline on each text element (Open-Sans
@@ -151,6 +218,12 @@ html {
 .docs-diagram foreignObject div,
 .docs-diagram foreignObject span {
   font-family: inherit !important;
+}
+/* Labels take a tight line-height instead of the prose column's, so node
+   boxes hug their text. */
+.docs-diagram foreignObject div,
+.docs-diagram foreignObject span {
+  line-height: 1.35;
 }
 
 /* Nodes and actors share one treatment: identity comes from a solid border
@@ -175,6 +248,10 @@ html {
   font-size: 14px !important;
   font-weight: 600 !important;
 }
+/* Sequence actors run 13px so four fit the prose column at full size. */
+.docs-diagram text.actor {
+  font-size: 13px !important;
+}
 .docs-diagram .cluster rect {
   fill: hsl(var(--b1)) !important;
   stroke: hsl(var(--bc) / 0.2) !important;
@@ -193,16 +270,31 @@ html {
 .docs-diagram .messageText,
 .docs-diagram .labelText,
 .docs-diagram .loopText {
-  font-size: 14px !important;
+  font-size: 13px !important;
+}
+/* Message labels get a page-coloured halo so they stay legible where they
+   cross a lifeline. */
+.docs-diagram text.messageText {
+  paint-order: stroke fill;
+  stroke: hsl(var(--b1)) !important;
+  stroke-width: 5px !important;
+  stroke-linejoin: round;
 }
 .docs-diagram .edgeLabel,
 .docs-diagram foreignObject div {
   color: hsl(var(--bc)) !important;
 }
+/* Flowchart edge labels are chips, so the line stops cleanly either side. */
 .docs-diagram .edgeLabel,
 .docs-diagram .edgeLabel rect {
   background-color: hsl(var(--b1)) !important;
   fill: hsl(var(--b1)) !important;
+}
+.docs-diagram .edgeLabel {
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 13px !important;
+  line-height: 1.35;
 }
 
 /* Line hierarchy: messages and edges, then lifelines, then frames. */
@@ -222,6 +314,12 @@ html {
 .docs-diagram marker.cross path {
   fill: none !important;
   stroke: hsl(var(--bc) / 0.75) !important;
+}
+/* Dotted edges are the convention for the browser's requests to Drupal,
+   where CORS applies. */
+.docs-diagram .edge-pattern-dotted {
+  stroke-dasharray: 2 4 !important;
+  stroke-linecap: round;
 }
 /* Mermaid 8 writes the actor height into the lifeline's class attribute
    (class="200"), so lifelines are matched by id. */

--- a/docs/nuxt/assets/css/code.css
+++ b/docs/nuxt/assets/css/code.css
@@ -1,0 +1,122 @@
+/* Code blocks and their copy button.
+
+   One dark surface in both themes: the site's strongest identity element and
+   a single Prism palette to maintain. The literals are the dark theme's own
+   tokens, kept as custom properties so a theme can override them. This
+   replaces the prism-themes CSS @nuxt/content used to inject. */
+:root {
+  --docs-code-bg: #16202b;
+  --docs-code-border: #243040;
+  --docs-code-fg: #e5ecf1;
+  --docs-code-key: #53b0eb;
+  --docs-code-string: #41b883;
+  --docs-code-number: #7cc5f1;
+}
+
+.prose pre {
+  position: relative;
+  padding: 20px 24px;
+  border: 1px solid var(--docs-code-border);
+  border-radius: 8px;
+  background-color: var(--docs-code-bg);
+  color: var(--docs-code-fg);
+  font-size: 14px;
+  line-height: 1.7;
+}
+@media (max-width: 639px) {
+  .prose pre {
+    padding: 16px;
+    font-size: 13px;
+  }
+}
+
+/* Prism tokens. Every token resolves to one of six roles. */
+.prose pre .token.key,
+.prose pre .token.property,
+.prose pre .token.attr-name,
+.prose pre .token.selector,
+.prose pre .token.tag,
+.prose pre .token.function,
+.prose pre .token.class-name {
+  color: var(--docs-code-key);
+}
+.prose pre .token.string,
+.prose pre .token.char,
+.prose pre .token.attr-value,
+.prose pre .token.template-string,
+.prose pre .token.inserted {
+  color: var(--docs-code-string);
+}
+.prose pre .token.number,
+.prose pre .token.constant,
+.prose pre .token.symbol,
+.prose pre .token.operator,
+.prose pre .token.url,
+.prose pre .token.entity,
+.prose pre .token.regex,
+.prose pre .token.variable {
+  color: var(--docs-code-number);
+}
+.prose pre .token.boolean,
+.prose pre .token.keyword,
+.prose pre .token.important {
+  color: var(--docs-code-fg);
+  font-weight: 700;
+}
+.prose pre .token.punctuation {
+  color: var(--docs-code-fg);
+  opacity: 0.5;
+}
+.prose pre .token.comment,
+.prose pre .token.prolog,
+.prose pre .token.doctype,
+.prose pre .token.cdata,
+.prose pre .token.deleted {
+  color: var(--docs-code-fg);
+  opacity: 0.6;
+  font-style: italic;
+}
+.prose pre .token.bold {
+  font-weight: 700;
+}
+.prose pre .token.italic {
+  font-style: italic;
+}
+
+/* Copy button, injected by AppProse. Always visible, so keyboard and touch
+   users get the same affordance as hover; it announces "Copied" through a
+   live region and reserves the wider label's width so the text swap does
+   not move the button. */
+.prose pre .docs-copy {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-grid;
+  padding: 4px 10px;
+  border: 1px solid rgb(255 255 255 / 0.15);
+  border-radius: 6px;
+  background-color: rgb(255 255 255 / 0.08);
+  color: rgb(229 236 241 / 0.85);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  transition: background-color 150ms, color 150ms, border-color 150ms;
+}
+.prose pre .docs-copy > span,
+.prose pre .docs-copy::after {
+  grid-area: 1 / 1;
+}
+.prose pre .docs-copy::after {
+  content: 'Copied';
+  visibility: hidden;
+}
+.prose pre .docs-copy:hover,
+.prose pre .docs-copy:focus-visible {
+  background-color: rgb(255 255 255 / 0.15);
+  color: var(--docs-code-fg);
+}
+.prose pre .docs-copy[data-state='copied'] {
+  border-color: hsl(var(--s) / 0.4);
+  color: hsl(var(--s));
+}

--- a/docs/nuxt/assets/css/code.css
+++ b/docs/nuxt/assets/css/code.css
@@ -83,10 +83,12 @@
   font-style: italic;
 }
 
-/* Copy button, injected by AppProse. Always visible, so keyboard and touch
-   users get the same affordance as hover; it announces "Copied" through a
-   live region and reserves the wider label's width so the text swap does
-   not move the button. */
+/* Copy button, injected by AppProse. It sits over the code, so it is hidden
+   until the reader shows intent: hovering the block, focusing it (AppProse
+   makes each block focusable, so a tap or Tab reveals it), or tabbing to the
+   button itself. Opaque, so the code beneath never bleeds through. It
+   announces "Copied" through a live region and reserves the wider label's
+   width so the text swap does not move the button. */
 .prose pre .docs-copy {
   position: absolute;
   top: 10px;
@@ -95,13 +97,20 @@
   padding: 4px 10px;
   border: 1px solid rgb(255 255 255 / 0.15);
   border-radius: 6px;
-  background-color: rgb(255 255 255 / 0.08);
+  background-color: #29323c;
+  background-color: color-mix(in srgb, var(--docs-code-bg), #fff 8%);
   color: rgb(229 236 241 / 0.85);
   font-size: 12px;
   font-weight: 500;
   line-height: 1.5;
   text-align: center;
-  transition: background-color 150ms, color 150ms, border-color 150ms;
+  opacity: 0;
+  transition: opacity 150ms, background-color 150ms, color 150ms, border-color 150ms;
+}
+.prose pre:hover .docs-copy,
+.prose pre:focus-within .docs-copy,
+.prose pre .docs-copy[data-state='copied'] {
+  opacity: 1;
 }
 .prose pre .docs-copy > span,
 .prose pre .docs-copy::after {
@@ -113,7 +122,8 @@
 }
 .prose pre .docs-copy:hover,
 .prose pre .docs-copy:focus-visible {
-  background-color: rgb(255 255 255 / 0.15);
+  background-color: #3a434c;
+  background-color: color-mix(in srgb, var(--docs-code-bg), #fff 15%);
   color: var(--docs-code-fg);
 }
 .prose pre .docs-copy[data-state='copied'] {

--- a/docs/nuxt/assets/css/code.css
+++ b/docs/nuxt/assets/css/code.css
@@ -83,16 +83,28 @@
   font-style: italic;
 }
 
+/* AppProse wraps each pre in .docs-code. The pre is the scroll region, so the
+   copy button anchors to the wrapper instead and stays put while the code
+   scrolls. The wrapper carries the block's margin. */
+.prose .docs-code {
+  position: relative;
+  margin: 1.5rem 0;
+}
+.prose .docs-code pre {
+  margin: 0;
+}
+
 /* Copy button, injected by AppProse. It sits over the code, so it is hidden
    until the reader shows intent: hovering the block, focusing it (AppProse
    makes each block focusable, so a tap or Tab reveals it), or tabbing to the
    button itself. Opaque, so the code beneath never bleeds through. It
    announces "Copied" through a live region and reserves the wider label's
    width so the text swap does not move the button. */
-.prose pre .docs-copy {
+.prose .docs-code .docs-copy {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  /* 10px inside the pre's 1px border. */
+  top: 11px;
+  right: 11px;
   display: inline-grid;
   padding: 4px 10px;
   border: 1px solid rgb(255 255 255 / 0.15);
@@ -107,26 +119,26 @@
   opacity: 0;
   transition: opacity 150ms, background-color 150ms, color 150ms, border-color 150ms;
 }
-.prose pre:hover .docs-copy,
-.prose pre:focus-within .docs-copy,
-.prose pre .docs-copy[data-state='copied'] {
+.prose .docs-code:hover .docs-copy,
+.prose .docs-code:focus-within .docs-copy,
+.prose .docs-code .docs-copy[data-state='copied'] {
   opacity: 1;
 }
-.prose pre .docs-copy > span,
-.prose pre .docs-copy::after {
+.prose .docs-code .docs-copy > span,
+.prose .docs-code .docs-copy::after {
   grid-area: 1 / 1;
 }
-.prose pre .docs-copy::after {
+.prose .docs-code .docs-copy::after {
   content: 'Copied';
   visibility: hidden;
 }
-.prose pre .docs-copy:hover,
-.prose pre .docs-copy:focus-visible {
+.prose .docs-code .docs-copy:hover,
+.prose .docs-code .docs-copy:focus-visible {
   background-color: #3a434c;
   background-color: color-mix(in srgb, var(--docs-code-bg), #fff 15%);
   color: var(--docs-code-fg);
 }
-.prose pre .docs-copy[data-state='copied'] {
+.prose .docs-code .docs-copy[data-state='copied'] {
   border-color: hsl(var(--s) / 0.4);
   color: hsl(var(--s));
 }

--- a/docs/nuxt/components/app/Figure.vue
+++ b/docs/nuxt/components/app/Figure.vue
@@ -1,15 +1,15 @@
 <template>
-  <figure class="my-0">
+  <figure class="docs-figure my-0">
     <button
       type="button"
-      class="block w-full rounded-box overflow-hidden border border-base-300 bg-base-200 cursor-[zoom-in]"
+      class="docs-figure-frame cursor-[zoom-in]"
       :aria-label="'Enlarge: ' + alt"
       @click="zoom = true"
     >
       <img :src="src" :alt="alt" class="block w-full" loading="lazy">
     </button>
 
-    <figcaption v-if="caption && alt" class="mt-2 text-sm text-base-content/55" v-text="alt" />
+    <figcaption v-if="caption && alt" v-text="alt" />
 
     <!--
       Screenshots of rendered Drupal data are dense; full-size viewing

--- a/docs/nuxt/components/app/Prose.vue
+++ b/docs/nuxt/components/app/Prose.vue
@@ -2,8 +2,8 @@
   <div ref="prose" class="prose">
     <!--
       Keyed on the document path so each document gets a brand-new subtree.
-      enhance() below rewrites DOM that NuxtContent owns — figures() wraps
-      each <img> in a <figure> and re-parents it — which leaves Vue patching
+      enhance() below rewrites DOM that NuxtContent owns - figures() wraps
+      each <img> in a <figure> and re-parents it - which leaves Vue patching
       against a tree that no longer matches its vnodes. Measured without the
       key, navigating blocks -> entity -> blocks: an orphaned empty <figure>
       persisted onto pages with no images at all, and returning to a
@@ -16,7 +16,7 @@
       Lightbox for prose images. figures() gives every image a cursor-zoom-in
       frame and a click handler; this renders the result locally rather than
       emitting to a parent, because the only consumer (pages/modules/_.vue)
-      never listened for it — the affordance was there but the click did
+      never listened for it - the affordance was there but the click did
       nothing. Mirrors AppFigure's own lightbox.
     -->
     <div
@@ -51,7 +51,7 @@ import { trapTab } from '~/utils/focus'
  *
  * @nuxt/content v1 has no prose component overrides, so the rendered output is
  * enhanced after mount. Everything here is a treatment of markdown the modules
- * already write — no content changes required:
+ * already write - no content changes required:
  *
  * - images become captioned, click-to-enlarge figures (alt text is the caption)
  * - code blocks get a copy button
@@ -203,7 +203,7 @@ export default {
         }
         // navigator.clipboard is undefined on non-secure origins (a preview
         // served over plain HTTP), and writeText can reject on a permission
-        // denial — without this the button silently never reacts and the
+        // denial - without this the button silently never reacts and the
         // rejection goes unhandled.
         button.addEventListener('click', async () => {
           try {

--- a/docs/nuxt/components/app/Prose.vue
+++ b/docs/nuxt/components/app/Prose.vue
@@ -169,6 +169,9 @@ export default {
     copyButtons(root) {
       root.querySelectorAll('pre:not([data-enhanced])').forEach((pre) => {
         pre.setAttribute('data-enhanced', '')
+        // Focusable, as a scrollable region should be, and so a tap or Tab
+        // reveals the copy button where there is no hover.
+        pre.tabIndex = 0
 
         const button = document.createElement('button')
         button.type = 'button'

--- a/docs/nuxt/components/app/Prose.vue
+++ b/docs/nuxt/components/app/Prose.vue
@@ -55,6 +55,7 @@ import { trapTab } from '~/utils/focus'
  *
  * - images become captioned, click-to-enlarge figures (alt text is the caption)
  * - code blocks get a copy button
+ * - tables get a keyboard-reachable scroll region and per-cell column labels
  * - the "For more details, refer to the … API documentation" lines the modules
  *   end each component section with become buttons rather than bullet points
  * - the `* * *` rules between sections are hidden; the headings already
@@ -94,6 +95,11 @@ export default {
     },
   },
 
+  created() {
+    // Plain property, not data: observers are not render state.
+    this.tableObservers = []
+  },
+
   mounted() {
     this.$nextTick(this.enhance)
     this.onKey = (e) => { if (e.key === 'Escape') this.zoom = null }
@@ -104,6 +110,7 @@ export default {
   beforeDestroy() {
     window.removeEventListener('keydown', this.onKey)
     document.documentElement.style.overflow = ''
+    this.disconnectTables()
   },
 
 
@@ -116,8 +123,10 @@ export default {
       const root = this.$refs.prose
       if (!root) return
 
+      this.disconnectTables()
       this.figures(root)
       this.copyButtons(root)
+      this.tables(root)
       this.apiLinks(root)
       root.querySelectorAll('hr').forEach((hr) => hr.setAttribute('data-decorative', ''))
     },
@@ -134,14 +143,14 @@ export default {
         }
 
         const figure = document.createElement('figure')
-        figure.className = 'not-prose my-8'
+        figure.className = 'docs-figure not-prose my-8'
 
         // A button, not a div: it was click-only, so the enlarge affordance
         // existed for a mouse and for nothing else. Keyboard users could not
         // reach it and screen readers were not told it did anything.
         const frame = document.createElement('button')
         frame.type = 'button'
-        frame.className = 'block w-full rounded-box overflow-hidden cursor-[zoom-in]'
+        frame.className = 'docs-figure-frame cursor-[zoom-in]'
         frame.setAttribute('aria-label', img.alt ? 'Enlarge: ' + img.alt : 'Enlarge image')
         frame.addEventListener('click', () => { this.zoom = { src: img.src, alt: img.alt } })
 
@@ -151,7 +160,6 @@ export default {
 
         if (img.alt) {
           const caption = document.createElement('figcaption')
-          caption.className = 'mt-2 text-sm text-base-content/55'
           caption.textContent = img.alt
           figure.appendChild(caption)
         }
@@ -161,40 +169,120 @@ export default {
     copyButtons(root) {
       root.querySelectorAll('pre:not([data-enhanced])').forEach((pre) => {
         pre.setAttribute('data-enhanced', '')
-        pre.classList.add('relative', 'group')
 
         const button = document.createElement('button')
         button.type = 'button'
-        button.textContent = 'Copy'
+        button.className = 'docs-copy'
         // A label, because every one of these otherwise reads as a bare
-        // "Copy". Its focus visibility lives in assets/css/app.css: with only
-        // a hover variant the button stayed fully transparent while focused —
-        // in the tab order, but invisible to the keyboard user on it.
+        // "Copy". The visible text is a span so code.css can reserve the
+        // wider "Copied" width behind it.
         button.setAttribute('aria-label', 'Copy code to clipboard')
-        button.className = 'absolute top-2 right-2 px-2 py-1 rounded-btn text-xs bg-white/10 text-white/70 opacity-0 group-hover:opacity-100 transition-opacity'
+        const label = document.createElement('span')
+        label.textContent = 'Copy'
+        button.appendChild(label)
+
+        // The state change is announced here, not by the button text: the
+        // button keeps its name, and the live region reaches screen readers
+        // whether or not focus is still on the button.
+        const status = document.createElement('span')
+        status.className = 'sr-only'
+        status.setAttribute('role', 'status')
+        status.setAttribute('aria-live', 'polite')
+
+        const code = pre.querySelector('code') || pre
+        let timer
+        const setState = (state, text, announce) => {
+          clearTimeout(timer)
+          label.textContent = text
+          status.textContent = announce
+          if (state) button.dataset.state = state
+          else delete button.dataset.state
+        }
         // navigator.clipboard is undefined on non-secure origins (a preview
         // served over plain HTTP), and writeText can reject on a permission
         // denial — without this the button silently never reacts and the
         // rejection goes unhandled.
         button.addEventListener('click', async () => {
           try {
-            await navigator.clipboard.writeText(pre.innerText.replace(/\nCopy$/, ''))
-            button.textContent = 'Copied'
+            await navigator.clipboard.writeText(code.innerText)
+            setState('copied', 'Copied', 'Copied to clipboard')
             // Only a successful copy counts. A clipboard rejection means the
             // reader did not get the snippet, and recording it as usage would
             // overstate exactly the metric this exists to measure.
             this.$track(...copyCodeEvent(
               this.$route.path,
-              languageFromClass(pre.className) || languageFromClass((pre.querySelector('code') || {}).className),
+              languageFromClass(pre.className) || languageFromClass(code.className),
             ))
           } catch (e) {
-            button.textContent = 'Copy failed'
+            setState('failed', 'Failed', 'Copy failed')
           }
-          setTimeout(() => { button.textContent = 'Copy' }, 1500)
+          timer = setTimeout(() => setState(null, 'Copy', ''), 2000)
         })
 
         pre.appendChild(button)
+        pre.appendChild(status)
       })
+    },
+
+    tables(root) {
+      root.querySelectorAll('table:not([data-enhanced])').forEach((table) => {
+        table.setAttribute('data-enhanced', '')
+
+        // Column headings become data-label on every body cell; the stacked
+        // layout in app.css prints them above each value below 640px.
+        const headings = Array.from(table.querySelectorAll('thead th')).map((th) => th.textContent.trim())
+        table.querySelectorAll('tbody tr').forEach((row) => {
+          Array.from(row.children).forEach((cell, i) => {
+            if (headings[i]) cell.setAttribute('data-label', headings[i])
+          })
+        })
+
+        const wrapper = document.createElement('div')
+        wrapper.className = 'docs-table'
+        if (headings.length) wrapper.setAttribute('data-stack', '')
+
+        const scroller = document.createElement('div')
+        scroller.className = 'docs-table-scroll'
+        scroller.setAttribute('role', 'region')
+        scroller.setAttribute('aria-label', this.tableLabel(table, root))
+
+        table.parentNode.insertBefore(wrapper, table)
+        scroller.appendChild(table)
+        wrapper.appendChild(scroller)
+
+        // A scroll region is only a tab stop while it scrolls; the fade shows
+        // only while there is more to the right.
+        const update = () => {
+          const overflow = scroller.scrollWidth > scroller.clientWidth + 1
+          const atEnd = scroller.scrollLeft + scroller.clientWidth >= scroller.scrollWidth - 1
+          wrapper.toggleAttribute('data-overflow', overflow && !atEnd)
+          if (overflow) scroller.setAttribute('tabindex', '0')
+          else scroller.removeAttribute('tabindex')
+        }
+        scroller.addEventListener('scroll', update, { passive: true })
+        if (window.ResizeObserver) {
+          const observer = new ResizeObserver(update)
+          observer.observe(scroller)
+          observer.observe(table)
+          this.tableObservers.push(observer)
+        }
+        update()
+      })
+    },
+
+    // The nearest heading above the table names its scroll region.
+    tableLabel(table, root) {
+      for (let node = table; node && node !== root; node = node.parentElement) {
+        for (let prev = node.previousElementSibling; prev; prev = prev.previousElementSibling) {
+          if (/^H[1-6]$/.test(prev.tagName)) return prev.textContent.trim()
+        }
+      }
+      return this.document.title || 'Table'
+    },
+
+    disconnectTables() {
+      this.tableObservers.forEach((observer) => observer.disconnect())
+      this.tableObservers = []
     },
 
     apiLinks(root) {

--- a/docs/nuxt/components/app/Prose.vue
+++ b/docs/nuxt/components/app/Prose.vue
@@ -173,6 +173,14 @@ export default {
         // reveals the copy button where there is no hover.
         pre.tabIndex = 0
 
+        // The button anchors to a wrapper, not the pre: the pre scrolls, and
+        // an absolutely positioned child of a scroll container scrolls with
+        // the code.
+        const wrapper = document.createElement('div')
+        wrapper.className = 'docs-code'
+        pre.parentNode.insertBefore(wrapper, pre)
+        wrapper.appendChild(pre)
+
         const button = document.createElement('button')
         button.type = 'button'
         button.className = 'docs-copy'
@@ -222,8 +230,8 @@ export default {
           timer = setTimeout(() => setState(null, 'Copy', ''), 2000)
         })
 
-        pre.appendChild(button)
-        pre.appendChild(status)
+        wrapper.appendChild(button)
+        wrapper.appendChild(status)
       })
     },
 

--- a/docs/nuxt/nuxt.config.js
+++ b/docs/nuxt/nuxt.config.js
@@ -97,7 +97,7 @@ export default {
     },
   },
 
-  css: ['~/assets/css/app.css'],
+  css: ['~/assets/css/app.css', '~/assets/css/code.css'],
   plugins: [
     '~/plugins/color-mode-theme.client.js',
     '~/plugins/analytics.client.js',
@@ -188,7 +188,8 @@ export default {
   content: {
     markdown: {
       // Anchors are what components/app/Toc.vue scroll-spies against.
-      prism: { theme: 'prism-themes/themes/prism-material-oceanic.css' },
+      // Token colours come from assets/css/code.css, not a Prism theme.
+      prism: { theme: false },
     },
   },
 

--- a/docs/nuxt/nuxt.config.js
+++ b/docs/nuxt/nuxt.config.js
@@ -1,9 +1,9 @@
 // GA4. @nuxtjs/google-analytics (the module this used to run through) only
-// ever spoke the Universal Analytics protocol via vue-analytics/analytics.js —
+// ever spoke the Universal Analytics protocol via vue-analytics/analytics.js -
 // UA stopped processing hits in July 2023, so it was silently collecting
 // nothing. Nuxt 3+'s replacement, nuxt-gtag, depends on @nuxt/kit and can't
 // run on this frozen Nuxt 2 stack, so this is a plain gtag.js snippet
-// instead — no new runtime dependency, same head.script mechanism the
+// instead - no new runtime dependency, same head.script mechanism the
 // colour-mode bridge already uses below.
 const GA_MEASUREMENT_ID = 'G-Y1ZRHGDGSD'
 
@@ -11,7 +11,7 @@ const GA_MEASUREMENT_ID = 'G-Y1ZRHGDGSD'
 // .lagoon.yml's `main` branch (druxtjs.org itself); every preview/branch
 // build gets 'development'. yarn generate runs inside Lagoon's own build
 // container (see docs/nuxt/Dockerfile), so this is set at generate time and
-// bakes the right answer into the static output per environment — preview
+// bakes the right answer into the static output per environment - preview
 // deploys never send hits into the real property.
 const isProduction = process.env.LAGOON_ENVIRONMENT_TYPE === 'production'
 
@@ -38,7 +38,7 @@ export default {
   // docs/nuxt/Dockerfile's final stage is `COPY --from=builder /app/docs/nuxt
   // /app`, so this file lands at /app/nuxt.config.js and `../../packages`
   // resolves outside the image. Verified: MODULE_NOT_FOUND in that layout,
-  // resolves fine from a repo checkout — which is why local and GitLab CI
+  // resolves fine from a repo checkout - which is why local and GitLab CI
   // `yarn generate` never caught it and only Lagoon deploys would break.
   // AppHeader's `v-if="version"` simply hides the badge when it is null.
   publicRuntimeConfig: {
@@ -54,7 +54,7 @@ export default {
       { hid: 'description', name: 'description', content: '' },
       { name: 'format-detection', content: 'telephone=no' },
     ],
-    // static/ ships icon.png, not a .ico — the old href 404s (on the live
+    // static/ ships icon.png, not a .ico - the old href 404s (on the live
     // site too, so this predates the redesign). @nuxtjs/pwa generates the
     // rest of the icon set from this same source image.
     link: [{ rel: 'icon', type: 'image/png', href: '/icon.png' }],
@@ -62,7 +62,7 @@ export default {
       // Sets data-theme before first paint, mirroring the localStorage/OS
       // preference logic @nuxtjs/color-mode runs internally. Needed because
       // 2.1.1 (the last Nuxt-2-compatible release) only supports writing a
-      // CSS class, not a data-theme attribute — see plugins/color-mode-
+      // CSS class, not a data-theme attribute - see plugins/color-mode-
       // theme.client.js for the reactive half of this bridge.
       {
         hid: 'druxt-theme-init',
@@ -72,7 +72,7 @@ export default {
       // vue-meta re-executes this inline script on every client-side
       // navigation, so gtag('config') re-fires and reports the destination
       // page. That means client-side routing is already counted and a
-      // router.afterEach page_view plugin would double-count them — measured
+      // router.afterEach page_view plugin would double-count them - measured
       // on a production-gated `yarn generate`, where one document load
       // produced js/config, then js/config again after a NuxtLink click.
       // Don't add one without re-measuring this first.
@@ -121,7 +121,7 @@ export default {
 
   // The daisyUI themes in tailwind.config.js are named 'light' and 'dark'.
   // color-mode@2.1.1 only toggles a CSS class (no data-theme support until
-  // v3, which requires Nuxt 3/4) — classSuffix: '' makes that class match
+  // v3, which requires Nuxt 3/4) - classSuffix: '' makes that class match
   // the theme name; plugins/color-mode-theme.client.js + the head.script
   // above bridge it to the data-theme attribute daisyUI actually reads.
   colorMode: {
@@ -202,7 +202,7 @@ export default {
      * fetches its entries client side, so most of those links do not exist in
      * the generated HTML for the crawler to follow. Measured before this: 50 of
      * 109 API pages were written to dist, and the other 59 existed only as the
-     * SPA fallback — served by 200.html, invisible to a crawler, and impossible
+     * SPA fallback - served by 200.html, invisible to a crawler, and impossible
      * to list in a sitemap honestly.
      *
      * @returns {string[]} Route paths to generate.

--- a/docs/nuxt/package.json
+++ b/docs/nuxt/package.json
@@ -28,7 +28,6 @@
     "@nuxtjs/storybook": "4.2.0",
     "@nuxtjs/tailwindcss": "4.2.1",
     "@resvg/resvg-js": "2.6.2",
-    "prism-themes": "1.9.0",
     "satori": "0.33.4",
     "tailwindcss": "^2.2.19"
   },

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -19,6 +19,8 @@ let mermaidReady
 // app.css text rules so mermaid measures what renders.
 const config = {
   startOnLoad: false,
+  // Mermaid's default, pinned: rendered SVG lands in the page via innerHTML.
+  securityLevel: 'strict',
   theme: 'neutral',
   fontFamily: 'inherit',
   flowchart: {

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -159,7 +159,7 @@ const renderAll = () => {
   if (!document.querySelector('pre code.language-mermaid, pre.language-mermaid code')) return
   ensureMermaid().then((mermaid) => {
     document.querySelectorAll('pre code.language-mermaid, pre.language-mermaid code').forEach((code) => {
-      const wrapper = code.closest('.nuxt-content-highlight') || code.closest('pre')
+      const wrapper = code.closest('.nuxt-content-highlight') || code.closest('.docs-code') || code.closest('pre')
       if (!wrapper) return
       const source = code.textContent.trim()
       const container = document.createElement('figure')

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -14,6 +14,8 @@
 
 let uid = 0
 let mermaidReady
+// Live observers, so navigation away from a page releases its diagrams.
+let observers = []
 
 // Layout values are the design spec; font sizes and weights match the
 // app.css text rules so mermaid measures what renders.
@@ -120,8 +122,20 @@ const wrap = (container, svg, label) => {
     else scroller.removeAttribute('tabindex')
   }
   scroller.addEventListener('scroll', update, { passive: true })
-  if (window.ResizeObserver) new ResizeObserver(update).observe(scroller)
+  if (window.ResizeObserver) {
+    const observer = new ResizeObserver(update)
+    observer.observe(scroller)
+    observers.push({ observer, target: scroller })
+  }
   update()
+}
+
+const disconnectStale = () => {
+  observers = observers.filter(({ observer, target }) => {
+    if (target.isConnected) return true
+    observer.disconnect()
+    return false
+  })
 }
 
 const renderInto = (mermaid, container, source) => {
@@ -159,6 +173,7 @@ const renderInto = (mermaid, container, source) => {
 }
 
 const renderAll = () => {
+  disconnectStale()
   if (!document.querySelector('pre code.language-mermaid, pre.language-mermaid code')) return
   ensureMermaid().then((mermaid) => {
     document.querySelectorAll('pre code.language-mermaid, pre.language-mermaid code').forEach((code) => {

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -139,7 +139,8 @@ const disconnectStale = () => {
 }
 
 const renderInto = (mermaid, container, source) => {
-  const label = (source.match(/^%% (.+)$/m) || [])[1]
+  // The caption is the first line only.
+  const label = (/^%% (.+)/.exec(source) || [])[1]
   try {
     fitActors(mermaid, container, source)
     mermaid.render(`docs-diagram-${uid++}`, source, (svg) => {

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -7,45 +7,122 @@
  * follow the colour mode live with no re-render. Until JavaScript runs,
  * the page shows the diagram source, which reads as a text description.
  *
- * Authoring contract: a first line of `%% <text>` becomes the SVG's
- * accessible label.
+ * Authoring contract: a first line of `%% <text>` becomes the figure's
+ * caption and the SVG's accessible name. Consecutive fences inside
+ * <div class="docs-diagram-row"> render as a row of cards (app.css).
  */
 
 let uid = 0
 let mermaidReady
+
+// Layout values are the design spec; font sizes and weights match the
+// app.css text rules so mermaid measures what renders.
+const config = {
+  startOnLoad: false,
+  theme: 'neutral',
+  fontFamily: 'inherit',
+  flowchart: {
+    useMaxWidth: true,
+    htmlLabels: true,
+    curve: 'monotoneX',
+    padding: 10,
+    nodeSpacing: 32,
+    rankSpacing: 48,
+    diagramPadding: 4,
+  },
+  sequence: {
+    useMaxWidth: true,
+    wrap: true,
+    width: 150,
+    height: 44,
+    actorMargin: 18,
+    diagramMarginX: 4,
+    diagramMarginY: 8,
+    boxMargin: 8,
+    boxTextMargin: 6,
+    noteMargin: 8,
+    messageMargin: 28,
+    mirrorActors: false,
+    bottomMarginAdj: 4,
+    actorFontSize: 13,
+    actorFontWeight: 600,
+    messageFontSize: 13,
+    noteFontSize: 13,
+  },
+}
+// Sequence actors size to fill the column the diagram sits in, so labels
+// render at their CSS size instead of scaling with the SVG.
+const actorWidth = { min: 120, max: 200 }
 
 // Only diagram pages pay for the library; everything else skips the chunk.
 const ensureMermaid = () => {
   mermaidReady =
     mermaidReady ||
     import('mermaid').then((m) => {
-      m.default.initialize({
-        startOnLoad: false,
-        theme: 'neutral',
-        fontFamily: 'inherit',
-        flowchart: { useMaxWidth: true },
-        // Wrapped messages keep four actors inside the 672px prose column,
-        // so labels stay at their CSS size instead of scaling down with
-        // the SVG. Font size and weight match the app.css text rules so
-        // layout measures what renders.
-        sequence: {
-          useMaxWidth: true,
-          wrap: true,
-          width: 150,
-          actorMargin: 20,
-          diagramMarginX: 8,
-          actorFontWeight: 600,
-          messageFontSize: 14,
-        },
-      })
+      m.default.initialize(config)
       return m.default
     })
   return mermaidReady
 }
 
+const participants = (source) => {
+  const declared = source.match(/^\s*(participant|actor)\s/gm)
+  if (declared) return declared.length
+  const ids = new Set()
+  source.replace(/^\s*([\w-]+)\s*(?:-->>|->>|-->|->|--x|-x|--\)|-\))\s*([\w-]+)\s*:/gm, (m, from, to) => {
+    ids.add(from)
+    ids.add(to)
+  })
+  return ids.size || 1
+}
+
+const fitActors = (mermaid, container, source) => {
+  if (!/^\s*sequenceDiagram/m.test(source)) return
+  const { diagramMarginX, actorMargin } = config.sequence
+  const n = participants(source)
+  const column = container.clientWidth
+  if (!column) return
+  const width = Math.floor((column - 2 * diagramMarginX - (n - 1) * actorMargin) / n)
+  mermaid.initialize({
+    ...config,
+    sequence: { ...config.sequence, width: Math.max(actorWidth.min, Math.min(actorWidth.max, width)) },
+  })
+}
+
+// figure > frame > scroller > svg, then the caption. The frame's fade and
+// the scroller's tab stop exist only while there is more to scroll.
+const wrap = (container, svg, label) => {
+  const frame = document.createElement('div')
+  frame.className = 'docs-diagram-frame'
+  const scroller = document.createElement('div')
+  scroller.className = 'docs-diagram-scroll'
+  scroller.appendChild(svg)
+  frame.appendChild(scroller)
+  container.innerHTML = ''
+  container.appendChild(frame)
+  if (label) {
+    const caption = document.createElement('figcaption')
+    caption.id = `${svg.id}-caption`
+    caption.textContent = label
+    container.appendChild(caption)
+    svg.setAttribute('aria-labelledby', caption.id)
+  }
+  const update = () => {
+    const overflow = scroller.scrollWidth > scroller.clientWidth + 1
+    const atEnd = scroller.scrollLeft + scroller.clientWidth >= scroller.scrollWidth - 1
+    frame.toggleAttribute('data-overflow', overflow && !atEnd)
+    if (overflow) scroller.setAttribute('tabindex', '0')
+    else scroller.removeAttribute('tabindex')
+  }
+  scroller.addEventListener('scroll', update, { passive: true })
+  if (window.ResizeObserver) new ResizeObserver(update).observe(scroller)
+  update()
+}
+
 const renderInto = (mermaid, container, source) => {
   const label = (source.match(/^%% (.+)$/m) || [])[1]
   try {
+    fitActors(mermaid, container, source)
     mermaid.render(`docs-diagram-${uid++}`, source, (svg) => {
       // Mermaid 8 reports parse failures through an empty callback rather
       // than a throw; fall back to the readable source either way.
@@ -55,19 +132,19 @@ const renderInto = (mermaid, container, source) => {
       }
       container.innerHTML = svg
       const el = container.querySelector('svg')
-      if (el) {
-        el.setAttribute('role', 'img')
-        if (label) el.setAttribute('aria-label', label)
-        el.removeAttribute('height')
-        // Drop mermaid's embedded stylesheet: its #id-prefixed rules outrank
-        // the site styles that give diagrams their colour-mode palette.
-        el.querySelectorAll('style').forEach((style) => style.remove())
-        // useMaxWidth scales the diagram to its column; on a phone that
-        // shrank 14px labels to 4px. app.css reads this floor below 640px,
-        // where the diagram then scrolls in its container instead.
-        const natural = parseFloat((el.getAttribute('viewBox') || '').split(/\s+/)[2])
-        if (natural) el.style.setProperty('--docs-diagram-floor', `${Math.round(natural * 0.7)}px`)
-      }
+      if (!el) return
+      el.setAttribute('role', 'img')
+      if (label) el.setAttribute('aria-label', label)
+      el.removeAttribute('height')
+      // Drop mermaid's embedded stylesheet: its #id-prefixed rules outrank
+      // the site styles that give diagrams their colour-mode palette.
+      el.querySelectorAll('style').forEach((style) => style.remove())
+      // useMaxWidth scales the diagram to its column; on a phone that
+      // shrank 14px labels to 4px. app.css reads this floor below 640px,
+      // where the diagram then scrolls in its frame instead.
+      const natural = parseFloat((el.getAttribute('viewBox') || '').split(/\s+/)[2])
+      if (natural) el.style.setProperty('--docs-diagram-floor', `${Math.round(natural * 0.85)}px`)
+      wrap(container, el, label)
     })
   } catch (e) {
     // Leave the readable source in place; a broken diagram must not take
@@ -83,8 +160,8 @@ const renderAll = () => {
       const wrapper = code.closest('.nuxt-content-highlight') || code.closest('pre')
       if (!wrapper) return
       const source = code.textContent.trim()
-      const container = document.createElement('div')
-      container.className = 'docs-diagram'
+      const container = document.createElement('figure')
+      container.className = 'docs-diagram not-prose'
       wrapper.replaceWith(container)
       renderInto(mermaid, container, source)
     })

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -24,7 +24,19 @@ const ensureMermaid = () => {
         theme: 'neutral',
         fontFamily: 'inherit',
         flowchart: { useMaxWidth: true },
-        sequence: { useMaxWidth: true },
+        // Wrapped messages keep four actors inside the 672px prose column,
+        // so labels stay at their CSS size instead of scaling down with
+        // the SVG. Font size and weight match the app.css text rules so
+        // layout measures what renders.
+        sequence: {
+          useMaxWidth: true,
+          wrap: true,
+          width: 150,
+          actorMargin: 20,
+          diagramMarginX: 8,
+          actorFontWeight: 600,
+          messageFontSize: 14,
+        },
       })
       return m.default
     })

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -50,6 +50,11 @@ const renderInto = (mermaid, container, source) => {
         // Drop mermaid's embedded stylesheet: its #id-prefixed rules outrank
         // the site styles that give diagrams their colour-mode palette.
         el.querySelectorAll('style').forEach((style) => style.remove())
+        // useMaxWidth scales the diagram to its column; on a phone that
+        // shrank 14px labels to 4px. app.css reads this floor below 640px,
+        // where the diagram then scrolls in its container instead.
+        const natural = parseFloat((el.getAttribute('viewBox') || '').split(/\s+/)[2])
+        if (natural) el.style.setProperty('--docs-diagram-floor', `${Math.round(natural * 0.7)}px`)
       }
     })
   } catch (e) {

--- a/docs/nuxt/plugins/mermaid.client.js
+++ b/docs/nuxt/plugins/mermaid.client.js
@@ -98,6 +98,9 @@ const wrap = (container, svg, label) => {
   frame.className = 'docs-diagram-frame'
   const scroller = document.createElement('div')
   scroller.className = 'docs-diagram-scroll'
+  // Named, because it is a tab stop while it overflows.
+  scroller.setAttribute('role', 'region')
+  scroller.setAttribute('aria-label', label || 'Diagram')
   scroller.appendChild(svg)
   frame.appendChild(scroller)
   container.innerHTML = ''

--- a/docs/nuxt/tailwind.config.js
+++ b/docs/nuxt/tailwind.config.js
@@ -51,11 +51,7 @@ const prose = (theme) => ({
     },
     'code::before': { content: 'none' },
     'code::after': { content: 'none' },
-    pre: {
-      backgroundColor: '#2f495e',
-      color: '#e5ecf1',
-      borderRadius: theme('borderRadius.lg'),
-    },
+    // pre: surface, Prism palette and copy button live in assets/css/code.css.
     'pre code': { backgroundColor: 'transparent', color: 'inherit', padding: 0 },
     blockquote: {
       borderLeftColor: colors.secondary,
@@ -67,8 +63,7 @@ const prose = (theme) => ({
     },
     'blockquote p:first-of-type::before': { content: 'none' },
     'blockquote p:last-of-type::after': { content: 'none' },
-    thead: { borderBottomColor: 'hsl(var(--b3))' },
-    'tbody tr': { borderBottomColor: 'hsl(var(--b3))' },
+    // table: header, row rules, scroll region and stacking live in assets/css/app.css.
     img: { borderRadius: theme('borderRadius.lg') },
     // Badges: linked images render as an inline row, not stacked blocks.
     'a > img': { display: 'inline-block', marginTop: '0', marginBottom: '0', borderRadius: '0' },

--- a/docs/nuxt/tailwind.config.js
+++ b/docs/nuxt/tailwind.config.js
@@ -17,7 +17,7 @@ const prose = (theme) => ({
     color: 'hsl(var(--bc) / 0.85)',
     // The docs link to Drupal.org issues and GitLab merge requests as bare
     // URLs, and an unbroken 600px link cannot be wrapped by normal word
-    // breaking — it pushed the whole page sideways on a phone. Measured on
+    // breaking - it pushed the whole page sideways on a phone. Measured on
     // /guide/multilingual at 375px: the document scrolled to 702px, moving
     // the header and sidebar with it. Only the long token breaks; ordinary
     // prose still wraps between words.
@@ -109,7 +109,7 @@ module.exports = {
     themes: [
       {
         light: {
-          // White stays the text colour on brand fills — the conventional
+          // White stays the text colour on brand fills - the conventional
           // look, and the brand hues below are untouched. The contrast
           // problem is solved in assets/css/app.css by filling the two
           // filled buttons with the darker in-family shade (primary-focus /

--- a/docs/nuxt/yarn.lock
+++ b/docs/nuxt/yarn.lock
@@ -10729,7 +10729,6 @@ __metadata:
     daisyui: 1.25.4
     mermaid: 8.14.0
     nuxt: 2.18.1
-    prism-themes: 1.9.0
     satori: 0.33.4
     tailwindcss: ^2.2.19
   languageName: unknown
@@ -18155,13 +18154,6 @@ __metadata:
   version: 1.1.0
   resolution: "pretty-time@npm:1.1.0"
   checksum: a319e7009aadbc6cfedbd8b66861327d3a0c68bd3e8794bf5b86f62b40b01b9479c5a70c76bb368ad454acce52a1216daee460cc825766e2442c04f3a84a02c9
-  languageName: node
-  linkType: hard
-
-"prism-themes@npm:1.9.0":
-  version: 1.9.0
-  resolution: "prism-themes@npm:1.9.0"
-  checksum: ddbadb8d83fc23e428409d7dd1d62dde6033a3afabd721d292e2d251f5693e3eccb7f9641704374f3df3dde59c0e2c8a3c069a7aa72990c4a00acb57f2af81f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The docs visual design implementation, stacked on #804 beside the review-5 branch.

- Diagram styling from the design tokens: node and line treatment, captions from the fence's first comment line, the card-row layout, mobile scale floor
- One Prism palette in code.css replacing the prism-themes dependency; copy button revealed on intent with a live status region
- Table scroll regions with keyboard reach and per-cell column labels for the stacked mobile layout
- Figure framing per the spec; mermaid securityLevel pinned explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated documentation code blocks with consistent dark-theme styling and clearer copy-button feedback.
  - Improved code copying with keyboard support, accessible announcements, and cleaner copied content.
  - Enhanced Mermaid diagrams with responsive sizing, scrolling, captions, and accessibility labels.
  - Added responsive table layouts with labeled scroll regions and stacked columns on smaller screens.
  - Refined image figure and screenshot presentation across documentation pages.
- **Chores**
  - Updated documentation styling configuration and spell-check vocabulary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->