### PR TITLE
feat(docs): dev container support, module page headers and accuracy fixes

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -191,6 +191,7 @@ wireframe
 wireframes
 worktree
 worktrees
+xvfb
 Xvfb
 yaml
 yamllint

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -4,7 +4,6 @@ antfu
 apos
 Appétit
 Autobuild
-autobuild
 automerge
 autoupdate
 axios
@@ -22,10 +21,8 @@ Codespaces
 Colour
 Colours
 Composables
-composables
 consola
 Consolas
-consolas
 Contenta
 contentacms
 corepack
@@ -42,7 +39,6 @@ defaultvalue
 devcontainer
 devcontainers
 Devel
-devel
 devpod
 Diataxis
 docgen
@@ -74,7 +70,6 @@ interruptible
 jsdocs
 jsonapi
 Knip
-knip
 Ksection
 labelledby
 langcode
@@ -87,7 +82,6 @@ libzip
 licence
 lightboxes
 Linkcheck
-linkcheck
 llms
 lockfiles
 longname
@@ -96,7 +90,6 @@ makedirs
 markdownlint
 mbstring
 Menlo
-menlo
 metatag
 metatags
 mise
@@ -104,7 +97,6 @@ namelist
 neighbour
 networkidle
 Neue
-neue
 nodetype
 nohup
 normalise
@@ -140,7 +132,6 @@ repage
 repoint
 reskins
 Resvg
-resvg
 router
 safelisted
 satori
@@ -148,7 +139,6 @@ scaffolder
 scriptable
 scule
 Segoe
-segoe
 setuptools
 shivammathur
 siroc
@@ -163,7 +153,6 @@ swipeable
 tailwindcss
 testid
 Themable
-themable
 toggleable
 topbar
 trixie
@@ -192,7 +181,6 @@ wireframes
 worktree
 worktrees
 Xvfb
-xvfb
 yaml
 yamllint
 yarnpkg

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -4,6 +4,7 @@ antfu
 apos
 Appétit
 Autobuild
+autobuild
 automerge
 autoupdate
 axios
@@ -21,8 +22,10 @@ Codespaces
 Colour
 Colours
 Composables
+composables
 consola
 Consolas
+consolas
 Contenta
 contentacms
 corepack
@@ -39,6 +42,7 @@ defaultvalue
 devcontainer
 devcontainers
 Devel
+devel
 devpod
 Diataxis
 docgen
@@ -70,6 +74,7 @@ interruptible
 jsdocs
 jsonapi
 Knip
+knip
 Ksection
 labelledby
 langcode
@@ -82,6 +87,7 @@ libzip
 licence
 lightboxes
 Linkcheck
+linkcheck
 llms
 lockfiles
 longname
@@ -90,6 +96,7 @@ makedirs
 markdownlint
 mbstring
 Menlo
+menlo
 metatag
 metatags
 mise
@@ -97,6 +104,7 @@ namelist
 neighbour
 networkidle
 Neue
+neue
 nodetype
 nohup
 normalise
@@ -132,6 +140,7 @@ repage
 repoint
 reskins
 Resvg
+resvg
 router
 safelisted
 satori
@@ -139,6 +148,7 @@ scaffolder
 scriptable
 scule
 Segoe
+segoe
 setuptools
 shivammathur
 siroc
@@ -153,6 +163,7 @@ swipeable
 tailwindcss
 testid
 Themable
+themable
 toggleable
 topbar
 trixie

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+{
+  "name": "Druxt",
+  "image": "mcr.microsoft.com/devcontainers/base:trixie",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "16.20.1"
+    },
+    // Installed through gh-release rather than the mise feature: that
+    // feature asks for the "latest" jdx/mise release and does not expose
+    // a tag filter, and mise now publishes vfox-* releases from the same
+    // repository. The regex keeps us on mise's own v-tags while still
+    // tracking the newest one.
+    "ghcr.io/devcontainers-extra/features/gh-release:1": {
+      "repo": "jdx/mise",
+      "binaryNames": "mise",
+      // mise ships the same build as .tar.gz, .tar.xz, .tar.zst and an
+      // extensionless binary; without this the resolver finds four
+      // matches and refuses to choose.
+      "assetRegex": ".tar.gz$",
+      "releaseTagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "containerEnv": {
+    // Node is provided by the devcontainer feature above - .mise.toml's
+    // pin is for host users. Without this, `mise install` tries to build
+    // Node from source inside the container.
+    "MISE_DISABLE_TOOLS": "node"
+  },
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Nuxt (docs site / examples)",
+      "onAutoForward": "silent"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        // Absolute path to where the gh-release feature installs the
+        // binary. The extension's default bare "mise" value is treated
+        // as workspace-relative, fails to hash, and re-prompts for
+        // approval on every config reload.
+        "mise.binPath": "/usr/local/bin/mise"
+      },
+      "extensions": [
+        "hverlin.mise-vscode",
+        "dbaeumer.vscode-eslint",
+        "EditorConfig.EditorConfig",
+        "davidanson.vscode-markdownlint",
+        "streetsidesoftware.code-spell-checker",
+        "redhat.vscode-yaml",
+        "Vue.volar"
+      ]
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Dev container setup: monorepo and docs-site dependencies. Drupal
+# backends are not provisioned here; use DDEV locally or a quickstart
+# repository for a backend.
+set -euo pipefail
+
+echo "==> Trusting this repo's .mise.toml"
+mise trust
+
+echo "==> Enabling corepack (Yarn 3, pinned by the packageManager field)"
+corepack enable
+
+echo "==> Installing monorepo dependencies"
+yarn install
+
+echo "==> Installing documentation site dependencies"
+(cd docs/nuxt && yarn install)
+
+cat <<'EOF'
+
+Ready. Common tasks:
+  yarn build            Build all packages
+  yarn test:unit        Run the unit test suite
+  yarn lint             Lint
+  yarn build:docs       Generate the API documentation
+  cd docs/nuxt && yarn dev   Run the druxtjs.org site locally
+
+EOF

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,8 +24,6 @@ CLAUDE.md          export-ignore
 .gitignore         export-ignore
 .gitlab-ci.yml     export-ignore
 .github            export-ignore
-.gitpod.yml        export-ignore
-.gitpod            export-ignore
 .circleci          export-ignore
 .changeset         export-ignore
 .husky             export-ignore

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ lint:json:
           rc=1
         fi
       done < <(find . -name '*.json' -not -path '*/.git/*' -not -path '*/node_modules/*' \
-        -not -path '*/dist/*' -not -path '*/.vscode/*' -not -path '*/templates/*' -print0)
+        -not -path '*/dist/*' -not -path '*/.vscode/*' -not -path '*/.devcontainer/*' -not -path '*/templates/*' -print0)
       echo "--- $count JSON file(s) checked ---"
       exit "$rc"
     - section_end "json-lint"

--- a/.prettierignore
+++ b/.prettierignore
@@ -35,7 +35,6 @@ package-lock.json
 test/__fixtures__/
 
 # ASCII art with intentional character-alignment whitespace
-.gitpod/WELCOME.md
 
 # Package templates (EJS / dynamic syntax prettier cannot parse)
 packages/*/templates/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ weight: 9
 description: Set up the Druxt development environment, report bugs, and submit changes with changesets and conventional commits.
 ---
 
-> All contributions are welcomed and appreciated.
+> Contributions are welcomed and appreciated.
 
 Druxt is an open source project, built, supported and maintained by the community, for the community.
 
@@ -12,7 +12,24 @@ Druxt is an open source project, built, supported and maintained by the communit
 
 ## Development environment setup
 
-The Druxt development environment runs locally:
+The Druxt development environment can be run in a dev container (VS Code, GitHub Codespaces, DevPod) or locally:
+
+---
+
+### Dev container
+
+`.devcontainer/devcontainer.json` provides a ready environment with Node 16 and Yarn via corepack. Monorepo and documentation dependencies install on first open.
+
+[![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/druxt/druxt.js)
+
+1. Go to the [druxt/druxt.js](https://github.com/druxt/druxt.js) and fork the repository. e.g., `https://github.com/USER/druxt.js`
+2. Open the fork in the tool of your choice:
+   - **VS Code**: clone, open the folder, run **Dev Containers: Reopen in Container**.
+   - **GitHub Codespaces**: on the repository page, **Code → Open with Codespaces**.
+   - **[DevPod](https://devpod.sh)**: run `devpod up github.com/USER/druxt.js`, or add the same URL as a workspace source in DevPod's desktop app.
+3. Wait for the post-create setup to finish, then build the packages: `yarn build`
+
+The container covers package development, unit tests, linting and the documentation site. It does not provision a Drupal backend. Use the `docs/drupal` `.devtools` flow (below) or a [quickstart repository](https://github.com/druxt/quickstart) when you need one.
 
 ---
 
@@ -25,7 +42,7 @@ The Druxt development environment runs locally:
 5. Start a Drupal backend (PHP 8.3 + SQLite, no Docker): `cd docs/drupal && .devtools/assemble && .devtools/provision && .devtools/start`
 6. Run DruxtSite example: `yarn example:druxt-site`
 
-> **Note:** If `make` is not available, run `corepack enable && yarn install` manually instead of `make setup`. This project uses [Yarn Berry](https://yarnpkg.com/) via [corepack](https://nodejs.org/api/corepack.html), which requires Node.js 16.9+ or 14.19+.
+> If `make` is not available, run `corepack enable && yarn install` manually instead of `make setup`. This project uses [Yarn Berry](https://yarnpkg.com/) via [corepack](https://nodejs.org/api/corepack.html), which requires Node.js 16.9+ or 14.19+.
 
 ---
 
@@ -39,7 +56,7 @@ When reporting bugs please make sure to provide detailed steps to reproduce the 
 
 ## Pull requests
 
-If you are able to resolve an issue, or have improvements you would like to propose, use following process to create a Pull request:
+To resolve an issue or propose an improvement, use the following process to create a Pull request:
 
 1. If this a new issue, make sure to open a bug report or feature request.
 2. Fork the repository.
@@ -52,9 +69,9 @@ If you are able to resolve an issue, or have improvements you would like to prop
 
 ## Example projects
 
-The Druxt monorepo contains a collection of example projects inside the aptly named "examples/" directory.
+The Druxt monorepo contains a collection of example projects inside the `examples/` directory.
 
-All projects are connected to the locally built codebase and should be used for testing during development.
+The example projects run against the locally built codebase, for testing during development.
 
 All examples use the Drupal instance located @ `docs/drupal` (`cd docs/drupal && .devtools/assemble && .devtools/provision && .devtools/start`).
 
@@ -98,6 +115,7 @@ The Druxt repository is setup with tools and automated processes to help with de
 - [Codecov](#codecov) - Automated code coverage
 - [Conventional commits](#conventional-commits) - Standardised commit messages
 - [Cypress](#cypress) - Automated end-to-end testing
+- [Dev container](#dev-container) - Ready-made development environment
 - [Docgen](#docgen) - Documentation generator
 - [Jest](#jest) - Automated unit testing
 - [Linting](#linting) - Coding styles and standards
@@ -137,7 +155,7 @@ yarn test:unit
 
 > A specification for adding human and machine readable meaning to commit messages
 
-The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of.
+The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history, which makes it easier to write automated tools on top of.
 
 A **husky** git hook is used to ensure the standard is enforced, and will explain what changes to make as required.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ and all dependencies installed on first open.
 
 [![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/druxt/druxt.js)
 
+### Dev container
+
+This repository ships a dev container (`.devcontainer/devcontainer.json`) for VS Code, GitHub Codespaces and [DevPod](https://devpod.sh), with Node, Yarn and all dependencies installed on first open.
+
+[![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/druxt/druxt.js)
+
 ## License
 
 [MIT](https://github.com/druxt/druxt.js/blob/develop/LICENSE)

--- a/docs/nuxt/components/app/DocFooter.vue
+++ b/docs/nuxt/components/app/DocFooter.vue
@@ -38,7 +38,7 @@ const EDIT_BASE = 'https://github.com/druxt/druxt.js/edit/develop/docs/nuxt/cont
 
 export default {
   props: {
-    /** Content-relative path, e.g. 'guide/getting-started.md'. */
+    /** Content-relative path, e.g. 'tutorials/getting-started.md'. */
     editPath: { type: String, default: null },
     prev: { type: Object, default: null },
     next: { type: Object, default: null },

--- a/docs/nuxt/content/explanation/component-resolution.md
+++ b/docs/nuxt/content/explanation/component-resolution.md
@@ -92,11 +92,7 @@ Separately from the suggestion system, any Druxt component accepts a
 `wrapper` prop that swaps the element wrapping its output:
 
 ```vue
-<DruxtEntity
-  type="node--article"
-  :uuid="uuid"
-  :wrapper="{ component: 'b', propsData: { class: 'title' } }"
-/>
+<DruxtEntity type="node--article" :uuid="uuid" :wrapper="{ component: 'b', class: 'title' }" />
 ```
 
 This composes with the theme layer: the wrapper component is resolved by

--- a/docs/nuxt/content/how-to/theming.md
+++ b/docs/nuxt/content/how-to/theming.md
@@ -130,3 +130,6 @@ button that scaffolds the file for you, wrapper path already filled in.
   same mechanism from the module author's side.
 - [Debug Druxt with the Vue Devtools](/how-to/devtools): inspect
   `component.options` live.
+- [Explore the example apps](/how-to/example-apps): the `druxt-site`
+  example includes a wrapper-theming pattern page, the wrapper system
+  running against real content.

--- a/docs/nuxt/content/modules/site/getting-started.md
+++ b/docs/nuxt/content/modules/site/getting-started.md
@@ -15,7 +15,7 @@ All Druxt sites need both Drupal (backend) and Nuxt (frontend) to be installed.
 
 Each codebase can live in its own directory within one repository, or exist in separate repositories.
 
-- For an example combining both into one repository, see the [Quickstart DruxtSite repository](https://github.com/druxt/quickstart-druxt-site).
+- For an example combining both into one repository, see the [Quickstart repository](https://github.com/druxt/quickstart).
 - For an example of individual repositories, see:
   - [Umami demo Nuxt repository](https://github.com/druxt/demo.druxtjs.org)
   - [Umami demo Drupal repository](https://github.com/druxt/demo-api.druxtjs.org)

--- a/docs/nuxt/content/tutorials/getting-started.md
+++ b/docs/nuxt/content/tutorials/getting-started.md
@@ -153,5 +153,7 @@ is the only file you'd change to point the frontend at a different Drupal.
   [Architecture](/explanation/architecture).
 - Start customizing the look: [Theme Druxt components](/how-to/theming).
 - Browse what each package does: [Druxt modules](/modules).
+- See finished Druxt sites running in production:
+  [demo.druxtjs.org](https://demo.druxtjs.org).
 - Something not working the way you expect? [Troubleshoot common
   issues](/how-to/troubleshooting).

--- a/docs/nuxt/pages/modules/_.vue
+++ b/docs/nuxt/pages/modules/_.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- docgen lifts the README's h1 into frontmatter, so without this the
          page has no h1 at all and its outline starts at h2. -->
-    <AppPageHeader v-if="document" :title="document.title" :description="document.description" />
+    <AppPageHeader v-if="document" :title="document.title" :description="document.description" :icon="icon" :mono="mono" />
 
     <!-- Every module README opens with a screenshot; it becomes the hero. -->
     <AppFigure v-if="hero" :src="hero.src" :alt="hero.alt" class="mb-8" />
@@ -18,6 +18,7 @@
 <script>
 import { seoHead } from '~/utils/seo'
 import { documentDescription, extractHero } from '~/utils/content'
+import { moduleIcon, moduleName } from '~/components/app/icon/module'
 
 export default {
   name: 'AppModuleDocument',
@@ -68,6 +69,10 @@ export default {
 
   computed: {
     editPath: ({ slug }) => 'modules/' + slug + '.md',
+
+    // The module's icon and npm name, matching its card on the index pages.
+    icon: ({ pkg }) => (pkg ? moduleIcon(pkg) : null),
+    mono: ({ pkg }) => (pkg ? moduleName(pkg) : null),
   },
 }
 </script>

--- a/packages/druxt/README.md
+++ b/packages/druxt/README.md
@@ -1,33 +1,129 @@
-# DruxtJS; The Fully Decoupled Drupal Framework
+<img src="./banner.svg" alt="Druxt: the core client, store and DruxtModule base">
+
+# Druxt
 
 [![npm](https://badgen.net/npm/v/druxt)](https://www.npmjs.com/package/druxt)
 [![CI](https://github.com/druxt/druxt.js/actions/workflows/ci.yml/badge.svg)](https://github.com/druxt/druxt.js/actions/workflows/ci.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/druxt/druxt.js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/druxt/druxt.js?targetFile=package.json)
 [![codecov](https://codecov.io/gh/druxt/druxt.js/branch/develop/graph/badge.svg)](https://codecov.io/gh/druxt/druxt.js)
 
-> Druxt = DRUpal + nUXT = Fully Decoupled Drupal.
+> The core module, DruxtClient, DruxtStore and the DruxtModule base component.
 
----
+The core `druxt` package is the foundation every other Druxt module builds
+on. It provides the three pieces the whole framework shares:
 
-## Links
+- **[DruxtClient](#druxtclient)**: the Drupal JSON:API communication layer.
+- **[DruxtStore](#druxtstore)**: the Vuex module caching resources and
+  collections for all modules.
+- **[DruxtModule](#druxtmodule)**: the base component behind the
+  theme-component suggestion system.
 
-- Documentation: https://druxtjs.org
-- Community Discord server: https://discord.gg/QnZD46c
-- Demo - Umami Food Magazine:
-  - https://demo.druxtjs.org
-  - https://druxt-umami.netlify.app
-  - https://umami-storybook.druxtjs.org
+## Installation
 
----
+1. Install the package:
 
-## Features
+   ```sh
+   npm i druxt
+   ```
 
-- Fully Decoupled Drupal, with [Nuxt.js](https://github.com/nuxt/nuxt.js#features) in the frontend.
-- Drupal JSON:API Client with Vuex caching.
-- Modular Vue.js component library system.
-- Slot and Wrapper theming system.
+2. Add the module and your backend URL to `nuxt.config.js`:
 
-Learn more at https://druxtjs.org
+   ```js
+   export default {
+     modules: [['druxt', { baseUrl: 'https://demo-api.druxtjs.org' }]],
+   };
+   ```
+
+   \* _Replace `https://demo-api.druxtjs.org` with your own
+   Drupal backend._
+
+3. On the Drupal side, install and enable the
+   [Druxt module](https://www.drupal.org/project/druxt) and grant the
+   **access druxt resources** permission to the relevant roles. Missing this
+   is the most common cause of site-wide JSON:API failures. See
+   [Troubleshooting](https://druxtjs.org/how-to/troubleshooting)
+   if requests are failing after install.
+
+## Compatibility
+
+As of September 2026. Current release: druxt 0.24.0, published November 2023.
+
+|               | Supported                                                                                                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Nuxt          | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported.                                                                                                                               |
+| Vue           | 2.7                                                                                                                                                                                 |
+| Node          | 16, the tested version. Node 16 is past upstream end of life; the 1.x line targets it deliberately. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build.            |
+| Drupal core   | 10.1 through 11 in practice: the module accepts 8.8+, but its Decoupled Router 2.x dependency requires 10.1. Tested against 10 and 11.                                              |
+| Drupal module | `drupal/druxt` ^1.2, which brings `decoupled_router`, `jsonapi_menu_items` and `jsonapi_views`. Hold `decoupled_router` below 2.0.7 ([#3618675](https://www.drupal.org/i/3618675)). |
+| Known pins    | `@nuxtjs/storybook` 4.2.0 (later majors need Nuxt 3); axios 0.x, or add it to `build.transpile`                                                                                     |
+
+What these bounds promise over time is stated in the
+[support and versioning policy](https://druxtjs.org/explanation/support-and-versioning).
+
+Translated routes additionally need a `decoupled_router` patch; see the
+[multilingual guide](https://druxtjs.org/how-to/multilingual).
+
+## Settings
+
+| Option        | Type              | Default      | Description                                                              |
+| ------------- | ----------------- | ------------ | ------------------------------------------------------------------------ |
+| `baseUrl`     | `string`          |              | The Drupal backend URL. **Required.**                                    |
+| `endpoint`    | `string`          | `'/jsonapi'` | The JSON:API endpoint path.                                              |
+| `proxy.api`   | `boolean`         | `false`      | Proxy API requests via Nuxt ([guide](https://druxtjs.org/how-to/proxy)). |
+| `proxy.files` | `boolean\|string` | `false`      | Proxy Drupal files. A string sets the site.                              |
+
+See the [Nuxt module API](https://druxtjs.org/api/packages/druxt/nuxt) for the full
+options list.
+
+## DruxtClient
+
+The client is the communication layer between your application and Drupal's
+JSON:API: resources, collections, indexing and authentication all flow
+through it.
+
+```js
+import { DruxtClient } from 'druxt';
+
+const client = new DruxtClient('https://demo-api.druxtjs.org');
+const collection = await client.getCollection('node--article');
+```
+
+- [Use the Druxt client directly](https://druxtjs.org/how-to/use-the-druxt-client): practical
+  guide, including non-Nuxt usage.
+- [DruxtClient API](https://druxtjs.org/api/packages/druxt/client): full method reference.
+
+## DruxtStore
+
+The Vuex module that all Druxt modules share: request deduplication, the
+resource/collection cache, and include handling.
+
+```js
+const resource = await this.$store.dispatch('druxt/getResource', {
+  type: 'node--article',
+  id: 'd8dfd355-7f2f-4fc3-a149-288e4e293bdd',
+});
+```
+
+- [The DruxtStore concept page](https://druxtjs.org/explanation/druxt-store): how it works
+  and why it exists.
+- [DruxtStore API](https://druxtjs.org/api/packages/druxt/stores/druxt): mutations and
+  actions.
+- [Deprecations](https://druxtjs.org/modules/druxt/deprecations): retired signatures.
+
+## DruxtModule
+
+The base component for all Druxt components: it turns a `druxt()` options
+object (component suggestions, props, slots) into themeable rendering.
+Building on it is covered by the
+[custom module tutorial](https://druxtjs.org/tutorials/first-custom-module), and the mechanism
+by [Component resolution](https://druxtjs.org/explanation/component-resolution).
+
+- [DruxtModule API](https://druxtjs.org/api/packages/druxt/components/DruxtModule).
+
+## Where to go next
+
+- New to Druxt? Start with the [Getting started tutorial](https://druxtjs.org/tutorials/getting-started).
+- Ready for the full site experience? See the [Site module](https://druxtjs.org/modules/site).
 
 ---
 
@@ -44,13 +140,23 @@ Learn more at https://druxtjs.org
 
 ---
 
+## Links
+
+- Documentation: https://druxtjs.org
+- Community Discord server: https://discord.druxtjs.org
+- Demo - Umami Food Magazine:
+  - https://demo.druxtjs.org
+  - https://storybook.umami.demo.druxtjs.org
+
+---
+
 ## Support
 
 Druxt is an open-source project, built by the community for the community.
 
 Find support or get involved in building Druxt via the community channels:
 
-- [DruxtJS Discord server](https://discord.gg/QnZD46c)
+- [DruxtJS Discord server](https://discord.druxtjs.org)
 - **#druxt** Slack channel on [Drupal.org slack](https://drupal.org/slack)
 
 ---

--- a/packages/druxt/README.md
+++ b/packages/druxt/README.md
@@ -1,129 +1,33 @@
-<img src="./banner.svg" alt="Druxt: the core client, store and DruxtModule base">
-
-# Druxt
+# DruxtJS; The Fully Decoupled Drupal Framework
 
 [![npm](https://badgen.net/npm/v/druxt)](https://www.npmjs.com/package/druxt)
 [![CI](https://github.com/druxt/druxt.js/actions/workflows/ci.yml/badge.svg)](https://github.com/druxt/druxt.js/actions/workflows/ci.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/druxt/druxt.js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/druxt/druxt.js?targetFile=package.json)
 [![codecov](https://codecov.io/gh/druxt/druxt.js/branch/develop/graph/badge.svg)](https://codecov.io/gh/druxt/druxt.js)
 
-> The core module, DruxtClient, DruxtStore and the DruxtModule base component.
+> Druxt = DRUpal + nUXT = Fully Decoupled Drupal.
 
-The core `druxt` package is the foundation every other Druxt module builds
-on. It provides the three pieces the whole framework shares:
+---
 
-- **[DruxtClient](#druxtclient)**: the Drupal JSON:API communication layer.
-- **[DruxtStore](#druxtstore)**: the Vuex module caching resources and
-  collections for all modules.
-- **[DruxtModule](#druxtmodule)**: the base component behind the
-  theme-component suggestion system.
+## Links
 
-## Installation
+- Documentation: https://druxtjs.org
+- Community Discord server: https://discord.druxtjs.org
+- Demo - Umami Food Magazine:
+  - https://demo.druxtjs.org
+  - https://druxt-umami.netlify.app
+  - https://umami-storybook.druxtjs.org
 
-1. Install the package:
+---
 
-   ```sh
-   npm i druxt
-   ```
+## Features
 
-2. Add the module and your backend URL to `nuxt.config.js`:
+- Fully Decoupled Drupal, with [Nuxt.js](https://github.com/nuxt/nuxt.js#features) in the frontend.
+- Drupal JSON:API Client with Vuex caching.
+- Modular Vue.js component library system.
+- Slot and Wrapper theming system.
 
-   ```js
-   export default {
-     modules: [['druxt', { baseUrl: 'https://demo-api.druxtjs.org' }]],
-   };
-   ```
-
-   \* _Replace `https://demo-api.druxtjs.org` with your own
-   Drupal backend._
-
-3. On the Drupal side, install and enable the
-   [Druxt module](https://www.drupal.org/project/druxt) and grant the
-   **access druxt resources** permission to the relevant roles. Missing this
-   is the most common cause of site-wide JSON:API failures. See
-   [Troubleshooting](https://druxtjs.org/how-to/troubleshooting)
-   if requests are failing after install.
-
-## Compatibility
-
-As of September 2026. Current release: druxt 0.24.0, published November 2023.
-
-|               | Supported                                                                                                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nuxt          | 2.15 or later (Nuxt 2 line). Nuxt 3 is not supported.                                                                                                                               |
-| Vue           | 2.7                                                                                                                                                                                 |
-| Node          | 16, the tested version. Node 16 is past upstream end of life; the 1.x line targets it deliberately. 17 and later need `NODE_OPTIONS=--openssl-legacy-provider` to build.            |
-| Drupal core   | 10.1 through 11 in practice: the module accepts 8.8+, but its Decoupled Router 2.x dependency requires 10.1. Tested against 10 and 11.                                              |
-| Drupal module | `drupal/druxt` ^1.2, which brings `decoupled_router`, `jsonapi_menu_items` and `jsonapi_views`. Hold `decoupled_router` below 2.0.7 ([#3618675](https://www.drupal.org/i/3618675)). |
-| Known pins    | `@nuxtjs/storybook` 4.2.0 (later majors need Nuxt 3); axios 0.x, or add it to `build.transpile`                                                                                     |
-
-What these bounds promise over time is stated in the
-[support and versioning policy](https://druxtjs.org/explanation/support-and-versioning).
-
-Translated routes additionally need a `decoupled_router` patch; see the
-[multilingual guide](https://druxtjs.org/how-to/multilingual).
-
-## Settings
-
-| Option        | Type              | Default      | Description                                                              |
-| ------------- | ----------------- | ------------ | ------------------------------------------------------------------------ |
-| `baseUrl`     | `string`          |              | The Drupal backend URL. **Required.**                                    |
-| `endpoint`    | `string`          | `'/jsonapi'` | The JSON:API endpoint path.                                              |
-| `proxy.api`   | `boolean`         | `false`      | Proxy API requests via Nuxt ([guide](https://druxtjs.org/how-to/proxy)). |
-| `proxy.files` | `boolean\|string` | `false`      | Proxy Drupal files. A string sets the site.                              |
-
-See the [Nuxt module API](https://druxtjs.org/api/packages/druxt/nuxt) for the full
-options list.
-
-## DruxtClient
-
-The client is the communication layer between your application and Drupal's
-JSON:API: resources, collections, indexing and authentication all flow
-through it.
-
-```js
-import { DruxtClient } from 'druxt';
-
-const client = new DruxtClient('https://demo-api.druxtjs.org');
-const collection = await client.getCollection('node--article');
-```
-
-- [Use the Druxt client directly](https://druxtjs.org/how-to/use-the-druxt-client): practical
-  guide, including non-Nuxt usage.
-- [DruxtClient API](https://druxtjs.org/api/packages/druxt/client): full method reference.
-
-## DruxtStore
-
-The Vuex module that all Druxt modules share: request deduplication, the
-resource/collection cache, and include handling.
-
-```js
-const resource = await this.$store.dispatch('druxt/getResource', {
-  type: 'node--article',
-  id: 'd8dfd355-7f2f-4fc3-a149-288e4e293bdd',
-});
-```
-
-- [The DruxtStore concept page](https://druxtjs.org/explanation/druxt-store): how it works
-  and why it exists.
-- [DruxtStore API](https://druxtjs.org/api/packages/druxt/stores/druxt): mutations and
-  actions.
-- [Deprecations](https://druxtjs.org/modules/druxt/deprecations): retired signatures.
-
-## DruxtModule
-
-The base component for all Druxt components: it turns a `druxt()` options
-object (component suggestions, props, slots) into themeable rendering.
-Building on it is covered by the
-[custom module tutorial](https://druxtjs.org/tutorials/first-custom-module), and the mechanism
-by [Component resolution](https://druxtjs.org/explanation/component-resolution).
-
-- [DruxtModule API](https://druxtjs.org/api/packages/druxt/components/DruxtModule).
-
-## Where to go next
-
-- New to Druxt? Start with the [Getting started tutorial](https://druxtjs.org/tutorials/getting-started).
-- Ready for the full site experience? See the [Site module](https://druxtjs.org/modules/site).
+Learn more at https://druxtjs.org
 
 ---
 
@@ -140,16 +44,6 @@ by [Component resolution](https://druxtjs.org/explanation/component-resolution).
 
 ---
 
-## Links
-
-- Documentation: https://druxtjs.org
-- Community Discord server: https://discord.druxtjs.org
-- Demo - Umami Food Magazine:
-  - https://demo.druxtjs.org
-  - https://storybook.umami.demo.druxtjs.org
-
----
-
 ## Support
 
 Druxt is an open-source project, built by the community for the community.
@@ -158,6 +52,14 @@ Find support or get involved in building Druxt via the community channels:
 
 - [DruxtJS Discord server](https://discord.druxtjs.org)
 - **#druxt** Slack channel on [Drupal.org slack](https://drupal.org/slack)
+
+---
+
+## Contributing
+
+[![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/druxt/druxt.js)
+
+See the [Contributing guide](https://github.com/druxt/druxt.js/blob/develop/CONTRIBUTING.md).
 
 ---
 

--- a/packages/druxt/README.md
+++ b/packages/druxt/README.md
@@ -12,7 +12,7 @@
 ## Links
 
 - Documentation: https://druxtjs.org
-- Community Discord server: https://discord.druxtjs.org
+- Community Discord server: https://discord.gg/QnZD46c
 - Demo - Umami Food Magazine:
   - https://demo.druxtjs.org
   - https://druxt-umami.netlify.app
@@ -50,7 +50,7 @@ Druxt is an open-source project, built by the community for the community.
 
 Find support or get involved in building Druxt via the community channels:
 
-- [DruxtJS Discord server](https://discord.druxtjs.org)
+- [DruxtJS Discord server](https://discord.gg/QnZD46c)
 - **#druxt** Slack channel on [Drupal.org slack](https://drupal.org/slack)
 
 ---


### PR DESCRIPTION
The lint-hardening branch rebuilt as its unique delta on top of the docs stack: dev container support replacing Gitpod, module page header icon and npm name, content accuracy fixes not superseded by the docs waves, JSONC CI fix, restored dictionary words, and readme/link repairs. The previous lineage duplicated the docs rebuild and the examples suite; both are now inherited from the base branches instead.