### PR TITLE
fix(docs): render the module identity once per page

### DIFF
--- a/docs/nuxt/components/app/ModuleHeader.vue
+++ b/docs/nuxt/components/app/ModuleHeader.vue
@@ -6,10 +6,20 @@
     bar simply scrolled away under the site header.
   -->
   <div>
-    <template v-if="pkg && module">
+    <template v-if="pkg">
       <!-- Full header: identity, description, Source. Pill-free per the
            approved boards; the package name is plain mono, not a badge. -->
       <header class="mx-auto max-w-content pb-5">
+        <!--
+          On a package's own route this block is the page header, so it owns
+          the h1. It cannot be the visible title: that is the dropdown
+          trigger, and a trigger is a <button>, whose content model is
+          phrasing content only - an h1 inside it is invalid and its heading
+          semantics are not reliably exposed. So the heading is here,
+          carrying the same text, and the visible title stays a span.
+        -->
+        <h1 v-if="isRoot" class="sr-only" v-text="title" />
+
         <div class="flex items-center gap-3 sm:gap-4">
           <span class="w-11 h-11 sm:w-14 sm:h-14 rounded-btn bg-base-200 text-primary-focus grid place-items-center flex-shrink-0">
             <component :is="icon" class="w-6 h-6 sm:w-8 sm:h-8" />
@@ -18,7 +28,7 @@
                machine name; menu behavior lives in AppDropdown. -->
           <AppDropdown :items="siblings" button-class="min-w-0 px-1 -mx-1 hover:bg-base-200">
             <span class="min-w-0 flex flex-col text-left sm:flex-row sm:items-baseline sm:gap-3">
-              <component :is="titleTag" class="text-2xl sm:text-3xl font-bold tracking-tight" v-text="module.title" />
+              <span class="text-2xl sm:text-3xl font-bold tracking-tight" v-text="title" />
               <span class="font-mono text-[13px] sm:text-[15px] text-primary-focus" v-text="name" />
             </span>
           </AppDropdown>
@@ -27,7 +37,7 @@
             <AppIconGithub class="w-4 h-4" /><span class="hidden sm:inline">Source</span>
           </a>
         </div>
-        <p v-if="module.description" class="mt-3 text-[15px] text-base-content/70" v-text="module.description" />
+        <p v-if="description" class="mt-3 text-[15px] text-base-content/70" v-text="description" />
       </header>
 
       <!-- The bar's stuck state flips when this sentinel passes under the
@@ -58,7 +68,7 @@
             <!-- The switcher works while stuck too, same trigger idiom. -->
             <AppDropdown :items="siblings" button-class="px-1.5 py-0.5 -mx-1 hover:bg-base-200">
               <span class="flex items-baseline gap-2">
-                <span class="text-[15px] sm:text-base font-bold" v-text="module.title" />
+                <span class="text-[15px] sm:text-base font-bold" v-text="title" />
                 <span class="hidden sm:inline font-mono text-[13px] text-primary-focus" v-text="name" />
               </span>
             </AppDropdown>
@@ -178,15 +188,41 @@ export default {
     },
 
     /**
-     * The element wrapping the module title. This block is the page header
-     * on a package's root pages, so it carries the h1 there; on the tab
-     * pages beneath them the page's own header owns the h1 instead.
+     * Whether this block is the page header for the current route, i.e. a
+     * package's own page rather than one of the tabs beneath it. The page
+     * components read the same test to skip their own header.
      *
      * @param {object} vm - The component ViewModel.
      * @param {object} vm.$route - The current route.
-     * @returns {string} The tag name to render.
+     * @returns {boolean} True on a package root.
      */
-    titleTag: ({ $route }) => (isPackageRoot($route.path) ? 'h1' : 'span'),
+    isRoot: ({ $route }) => isPackageRoot($route.path),
+
+    /**
+     * The module's display title, falling back to the package name when the
+     * generated README is missing.
+     *
+     * The fallback is load-bearing, not cosmetic: on a package root the page
+     * component suppresses its own header because this one is showing, so a
+     * header that declined to render would leave the page with no title and
+     * no source link at all. Rendering on `pkg` alone keeps that invariant
+     * true rather than hoping the README fetch succeeded.
+     *
+     * @param {object} vm - The component ViewModel.
+     * @param {?object} vm.module - The module's README document, or null.
+     * @param {string} vm.name - The npm package name.
+     * @returns {string} The title to display.
+     */
+    title: ({ module, name }) => (module || {}).title || name,
+
+    /**
+     * The module's description, when the README supplied one.
+     *
+     * @param {object} vm - The component ViewModel.
+     * @param {?object} vm.module - The module's README document, or null.
+     * @returns {?string} The description, or null.
+     */
+    description: ({ module }) => (module || {}).description || null,
 
     /**
      * The npm package name shown in mono; plain `druxt` for the core.

--- a/docs/nuxt/components/app/ModuleHeader.vue
+++ b/docs/nuxt/components/app/ModuleHeader.vue
@@ -317,9 +317,15 @@ export default {
   watch: {
     // Refetch only when the module changes; switching tabs within one
     // module keeps the header exactly as it is - that is the point.
+    //
+    // The sentinel is rebound here rather than on `module`, because the
+    // header renders on `pkg` alone: arriving at a package whose README
+    // fails to load leaves `module` null, so a `module` watcher never
+    // fires and the sticky bar would never engage.
     pkg() {
       this.open = false
       this.$fetch()
+      this.$nextTick(() => this.observe())
     },
 
     $route() {
@@ -342,11 +348,6 @@ export default {
           }))
         })
       }
-    },
-
-    // The sentinel only exists while a module is shown; rebind around it.
-    module() {
-      this.$nextTick(() => this.observe())
     },
   },
 

--- a/docs/nuxt/components/app/ModuleHeader.vue
+++ b/docs/nuxt/components/app/ModuleHeader.vue
@@ -18,7 +18,7 @@
                machine name; menu behavior lives in AppDropdown. -->
           <AppDropdown :items="siblings" button-class="min-w-0 px-1 -mx-1 hover:bg-base-200">
             <span class="min-w-0 flex flex-col text-left sm:flex-row sm:items-baseline sm:gap-3">
-              <span class="text-2xl sm:text-3xl font-bold tracking-tight" v-text="module.title" />
+              <component :is="titleTag" class="text-2xl sm:text-3xl font-bold tracking-tight" v-text="module.title" />
               <span class="font-mono text-[13px] sm:text-[15px] text-primary-focus" v-text="name" />
             </span>
           </AppDropdown>
@@ -116,7 +116,7 @@
 </template>
 
 <script>
-import { moduleIcon, moduleName, modulePkgs } from './icon/module'
+import { isPackageRoot, moduleIcon, moduleName, modulePkgs } from './icon/module'
 
 export default {
   data: () => ({
@@ -176,6 +176,17 @@ export default {
         : null
       return candidate && modulePkgs.includes(candidate) ? candidate : null
     },
+
+    /**
+     * The element wrapping the module title. This block is the page header
+     * on a package's root pages, so it carries the h1 there; on the tab
+     * pages beneath them the page's own header owns the h1 instead.
+     *
+     * @param {object} vm - The component ViewModel.
+     * @param {object} vm.$route - The current route.
+     * @returns {string} The tag name to render.
+     */
+    titleTag: ({ $route }) => (isPackageRoot($route.path) ? 'h1' : 'span'),
 
     /**
      * The npm package name shown in mono; plain `druxt` for the core.

--- a/docs/nuxt/components/app/PageHeader.vue
+++ b/docs/nuxt/components/app/PageHeader.vue
@@ -10,18 +10,7 @@
       />
     </div>
 
-    <div class="flex items-center gap-4">
-      <span
-        v-if="icon"
-        class="w-12 h-12 rounded-btn bg-base-200 text-primary-focus grid place-items-center flex-shrink-0"
-      >
-        <component :is="icon" class="w-7 h-7" />
-      </span>
-      <div class="min-w-0">
-        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight" v-text="title" />
-        <p v-if="mono" class="mt-1 font-mono text-sm text-base-content/70" v-text="mono" />
-      </div>
-    </div>
+    <h1 class="text-3xl sm:text-4xl font-bold tracking-tight" v-text="title" />
 
     <p v-if="description" class="mt-3 text-lg text-base-content/70" v-text="description" />
 
@@ -36,10 +25,6 @@ export default {
     description: { type: String, default: null },
     /** [{ text, class }] */
     badges: { type: Array, default: () => [] },
-    /** Icon component rendered in a tile beside the title. */
-    icon: { type: Object, default: null },
-    /** Monospace identity line under the title, e.g. the npm package name. */
-    mono: { type: String, default: null },
   },
 }
 </script>

--- a/docs/nuxt/components/app/icon/module/index.js
+++ b/docs/nuxt/components/app/icon/module/index.js
@@ -32,6 +32,9 @@ export const modulePkgs = Object.keys(moduleIcons)
  */
 export const moduleName = (pkg) => (pkg === 'druxt' ? 'druxt' : 'druxt-' + pkg)
 
+/** Filenames whose route is their containing directory, per lib/content-index. */
+const INDEX_SEGMENTS = ['index', 'README']
+
 /**
  * Whether a route is a module package's root page, where the layout's module
  * header carries the page's own title and source link: `/modules/<pkg>` and
@@ -42,10 +45,25 @@ export const moduleName = (pkg) => (pkg === 'druxt' ? 'druxt' : 'druxt-' + pkg)
  * @returns {boolean} True on a covered package's root page.
  */
 export const isPackageRoot = (path) => {
-  const [, first, second, third, fourth] = path.replace(/\/+$/, '').split('/')
-  if (fourth) return false
-  if (first === 'modules') return !third && modulePkgs.includes(second)
-  return first === 'api' && second === 'packages' && modulePkgs.includes(third)
+  // Every empty segment dropped, not just the leading and trailing ones: a
+  // `//` inside a path leaves a '' between the parts, and '' is falsy, so a
+  // positional guard reads `/api/packages/entity//CHANGELOG` as having no
+  // fourth segment and calls it a package root.
+  const segments = path.split('/').filter(Boolean)
+
+  // A package root is reachable at a second URL: the sitemap lists the
+  // collapsed path, but the source filename resolves too, so
+  // `/modules/<pkg>/README` and `/api/packages/<pkg>/index` are the same
+  // pages as `/modules/<pkg>` and `/api/packages/<pkg>`. The rule has to
+  // reach both, or the longer URL prints the module identity twice.
+  if (INDEX_SEGMENTS.includes(segments[segments.length - 1])) segments.pop()
+
+  // Counted, not probed positionally: the original asked whether a later
+  // segment was truthy, which is the question that let '' through.
+  const [first, second, third] = segments
+  if (segments.length === 2 && first === 'modules') return modulePkgs.includes(second)
+
+  return segments.length === 3 && first === 'api' && second === 'packages' && modulePkgs.includes(third)
 }
 
 /**

--- a/docs/nuxt/components/app/icon/module/index.js
+++ b/docs/nuxt/components/app/icon/module/index.js
@@ -33,6 +33,22 @@ export const modulePkgs = Object.keys(moduleIcons)
 export const moduleName = (pkg) => (pkg === 'druxt' ? 'druxt' : 'druxt-' + pkg)
 
 /**
+ * Whether a route is a module package's root page, where the layout's module
+ * header carries the page's own title and source link: `/modules/<pkg>` and
+ * `/api/packages/<pkg>`. The page components read this to skip a header that
+ * would otherwise print the module identity a second time.
+ *
+ * @param {string} path - The route path.
+ * @returns {boolean} True on a covered package's root page.
+ */
+export const isPackageRoot = (path) => {
+  const [, first, second, third, fourth] = path.replace(/\/+$/, '').split('/')
+  if (fourth) return false
+  if (first === 'modules') return !third && modulePkgs.includes(second)
+  return first === 'api' && second === 'packages' && modulePkgs.includes(third)
+}
+
+/**
  * The icon component for a module package.
  *
  * @param {string} pkg - The package directory name, e.g. 'entity'.

--- a/docs/nuxt/content/modules/druxt/deprecations.md
+++ b/docs/nuxt/content/modules/druxt/deprecations.md
@@ -4,8 +4,6 @@ weight: 10
 description: Retired DruxtStore signatures and internal classes, with their replacements.
 ---
 
-# Deprecations
-
 ## DruxtStore / addResource - hash
 
 > [druxt] The `hash` argument for `druxt/addResource` has been deprecated.

--- a/docs/nuxt/content/modules/entity/deprecations.md
+++ b/docs/nuxt/content/modules/entity/deprecations.md
@@ -4,8 +4,6 @@ weight: 10
 description: Retired DruxtField default components and props, with their replacements.
 ---
 
-# Deprecations
-
 ## DruxtField default components
 
 > [druxt-entity] The `*` component is deprecated.

--- a/docs/nuxt/content/modules/menu/deprecations.md
+++ b/docs/nuxt/content/modules/menu/deprecations.md
@@ -4,8 +4,6 @@ weight: 10
 description: The retired DruxtMenu items computed property, and what replaces it.
 ---
 
-# Deprecations
-
 ## DruxtMenu / items computed
 
 > [druxt-menu] The `items` computed property is deprecated.

--- a/docs/nuxt/content/modules/router/deprecations.md
+++ b/docs/nuxt/content/modules/router/deprecations.md
@@ -4,8 +4,6 @@ weight: 10
 description: Retired DruxtRouter client and store members, with their replacements.
 ---
 
-# Deprecations
-
 ## DruxtRouter pass-through methods
 
 > [druxt-router] Use the DruxtClient directly.

--- a/docs/nuxt/pages/api/_.vue
+++ b/docs/nuxt/pages/api/_.vue
@@ -1,7 +1,9 @@
 <template>
   <article>
 
-    <AppPageHeader :title="document.title">
+    <!-- Skipped on a package's API root: the layout's module header there
+         carries the same title and the same source link. -->
+    <AppPageHeader v-if="!inModuleHeader" :title="document.title">
       <a
         v-if="source"
         class="mt-5 inline-flex items-center gap-2 text-sm text-base-content/70 hover:text-primary-focus"
@@ -20,6 +22,7 @@
 <script>
 import { seoHead } from '~/utils/seo'
 import { documentDescription } from '~/utils/content'
+import { isPackageRoot } from '~/components/app/icon/module'
 export default {
   name: 'AppApiDocument',
 
@@ -52,6 +55,16 @@ export default {
   },
 
   computed: {
+    /**
+     * Whether the layout's module header is already this page's header,
+     * carrying the same title and the same source link.
+     *
+     * @param {object} vm - The component ViewModel.
+     * @param {object} vm.$route - The current route.
+     * @returns {boolean} True on a module package's API root.
+     */
+    inModuleHeader: ({ $route }) => isPackageRoot($route.path),
+
     source: ({ document }) => (document.dir
       ? 'https://github.com/druxt/druxt.js/tree/develop' + document.dir.replace('/api/packages', '/packages')
       : null),

--- a/docs/nuxt/pages/modules/_.vue
+++ b/docs/nuxt/pages/modules/_.vue
@@ -1,8 +1,10 @@
 <template>
   <div>
-    <!-- docgen lifts the README's h1 into frontmatter, so without this the
-         page has no h1 at all and its outline starts at h2. -->
-    <AppPageHeader v-if="document" :title="document.title" :description="document.description" :icon="icon" :mono="mono" />
+    <!-- The page's own title, for the tab pages under a module. Skipped on
+         the module's own route, where the layout's module header is already
+         the page header: rendering both printed the identity block twice,
+         icon and package name included. -->
+    <AppPageHeader v-if="document && !inModuleHeader" :title="document.title" :description="document.description" />
 
     <!-- Every module README opens with a screenshot; it becomes the hero. -->
     <AppFigure v-if="hero" :src="hero.src" :alt="hero.alt" class="mb-8" />
@@ -18,7 +20,7 @@
 <script>
 import { seoHead } from '~/utils/seo'
 import { documentDescription, extractHero } from '~/utils/content'
-import { moduleIcon, moduleName } from '~/components/app/icon/module'
+import { isPackageRoot } from '~/components/app/icon/module'
 
 export default {
   name: 'AppModuleDocument',
@@ -70,9 +72,16 @@ export default {
   computed: {
     editPath: ({ slug }) => 'modules/' + slug + '.md',
 
-    // The module's icon and npm name, matching its card on the index pages.
-    icon: ({ pkg }) => (pkg ? moduleIcon(pkg) : null),
-    mono: ({ pkg }) => (pkg ? moduleName(pkg) : null),
+    /**
+     * Whether the layout's module header is already serving as this page's
+     * header, in which case repeating it here prints the module identity
+     * twice.
+     *
+     * @param {object} vm - The component ViewModel.
+     * @param {object} vm.$route - The current route.
+     * @returns {boolean} True when the header above already names this page.
+     */
+    inModuleHeader: ({ $route }) => isPackageRoot($route.path),
   },
 }
 </script>

--- a/docs/nuxt/test/cypress/e2e/modules.cy.js
+++ b/docs/nuxt/test/cypress/e2e/modules.cy.js
@@ -20,6 +20,15 @@ it('DruxtJS.org: Modules', () => {
   // identity is named once, not once by the header and again by the page.
   cy.get('h1').should('have.length', 1).and('have.text', 'Entity')
 
+  // Counting h1s cannot see one nested somewhere it may not be. The visible
+  // title is a dropdown trigger, so a heading placed there ships inside a
+  // <button>, which takes phrasing content only.
+  cy.get('button h1').should('not.exist')
+
+  // The same page at the URL its source filename spells out.
+  cy.visit('/modules/entity/README')
+  cy.get('h1').should('have.length', 1).and('have.text', 'Entity')
+
   cy.visit('/api/packages/entity')
   cy.get('h1').should('have.length', 1).and('have.text', 'Entity')
 

--- a/docs/nuxt/test/cypress/e2e/modules.cy.js
+++ b/docs/nuxt/test/cypress/e2e/modules.cy.js
@@ -15,4 +15,15 @@ it('DruxtJS.org: Modules', () => {
   cy.get('nav[aria-label="Breadcrumb"]').should('contain', 'Modules')
   cy.contains('a', 'Source').should('have.attr', 'href').and('include', 'github.com/druxt')
   cy.contains('a', 'Changelog').should('have.attr', 'href', '/api/packages/entity/CHANGELOG')
+
+  // The module header is the page header on a package root, so the module
+  // identity is named once, not once by the header and again by the page.
+  cy.get('h1').should('have.length', 1).and('have.text', 'Entity')
+
+  cy.visit('/api/packages/entity')
+  cy.get('h1').should('have.length', 1).and('have.text', 'Entity')
+
+  // A page under a module keeps its own title, and only its own.
+  cy.visit('/modules/entity/deprecations')
+  cy.get('h1').should('have.length', 1).and('have.text', 'DruxtEntity deprecations')
 })

--- a/docs/nuxt/test/unit/module-header.test.js
+++ b/docs/nuxt/test/unit/module-header.test.js
@@ -1,0 +1,104 @@
+import Vue from 'vue'
+import { createLocalVue, mount } from '@vue/test-utils'
+
+import ModuleHeader from '~/components/app/ModuleHeader.vue'
+
+const localVue = createLocalVue()
+
+let observed
+
+/**
+ * Mounts the header at a starting route, with the module README missing.
+ *
+ * `$content` rejects, which is what a package whose generated README has
+ * not been written looks like: the component's own catch leaves `module`
+ * null, and the header still has to render because the page components
+ * suppress theirs on these routes.
+ *
+ * @param {string} path - The starting route path.
+ * @returns {object} The Vue Test Utils wrapper.
+ */
+const mountHeader = (path) => {
+  // Reactive, so assigning `$route.path` re-evaluates `pkg` as a real
+  // navigation would.
+  const $route = Vue.observable({ path })
+
+  return mount(ModuleHeader, {
+    localVue,
+    mocks: {
+      $route,
+      $fetch: jest.fn(),
+      $content: () => ({
+        only: () => ({ fetch: () => Promise.reject(new Error('no README')) }),
+        fetch: () => Promise.reject(new Error('no README')),
+      }),
+      $store: { state: { modules: [] } },
+    },
+    stubs: ['AppDropdown', 'AppIconGithub', 'NuxtLink'],
+  })
+}
+
+beforeEach(() => {
+  observed = []
+  global.IntersectionObserver = class {
+    /** @param {Function} callback - The observer callback. */
+    constructor(callback) {
+      this.callback = callback
+    }
+
+    /** @param {object} el - The observed element. */
+    observe(el) {
+      observed.push(el)
+    }
+
+    /** Stops observing. */
+    disconnect() {}
+  }
+})
+
+describe('AppModuleHeader', () => {
+  // The header renders on `pkg` alone, so the sentinel appears for a
+  // package whose README never loads. Binding the observer on `module`
+  // meant it was never observed on that path and the bar never stuck.
+  test('observes the sentinel when the route reaches a package without a README', async () => {
+    const wrapper = mountHeader('/how-to/proxy')
+    expect(wrapper.vm.pkg).toBe(null)
+    expect(observed).toHaveLength(0)
+
+    wrapper.vm.$route.path = '/modules/entity'
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.pkg).toBe('entity')
+    expect(wrapper.vm.module).toBe(null)
+    expect(observed).toHaveLength(1)
+    expect(observed[0]).toBe(wrapper.vm.$refs.sentinel)
+
+    wrapper.destroy()
+  })
+
+  // The title has to name the page even with no README, because the page
+  // component is not rendering a header of its own on this route.
+  test('falls back to the package name when the README is missing', () => {
+    const wrapper = mountHeader('/modules/entity')
+
+    expect(wrapper.vm.module).toBe(null)
+    expect(wrapper.vm.title).toBe('druxt-entity')
+    expect(wrapper.vm.description).toBe(null)
+    expect(wrapper.find('h1').text()).toBe('druxt-entity')
+    expect(wrapper.find('h1').classes()).toContain('sr-only')
+
+    wrapper.destroy()
+  })
+
+  // A heading inside the dropdown's <button> is invalid and unreliably
+  // exposed; counting h1s cannot see it, so the placement is pinned here.
+  test('keeps the heading out of the dropdown trigger', () => {
+    const wrapper = mountHeader('/modules/entity')
+
+    expect(wrapper.findAll('h1')).toHaveLength(1)
+    expect(wrapper.find('button h1').exists()).toBe(false)
+
+    wrapper.destroy()
+  })
+})

--- a/docs/nuxt/test/unit/module-package-root.test.js
+++ b/docs/nuxt/test/unit/module-package-root.test.js
@@ -1,0 +1,42 @@
+import { isPackageRoot, moduleName, modulePkgs } from '~/components/app/icon/module'
+
+describe('isPackageRoot', () => {
+  test('module and API roots of a known package', () => {
+    expect(isPackageRoot('/modules/entity')).toBe(true)
+    expect(isPackageRoot('/modules/entity/')).toBe(true)
+    expect(isPackageRoot('/api/packages/entity')).toBe(true)
+    expect(isPackageRoot('/api/packages/entity/')).toBe(true)
+  })
+
+  test('every module package is covered', () => {
+    for (const pkg of modulePkgs) {
+      expect(isPackageRoot('/modules/' + pkg)).toBe(true)
+      expect(isPackageRoot('/api/packages/' + pkg)).toBe(true)
+    }
+  })
+
+  // These are the pages that keep their own header: the module header above
+  // them names the module, not the page.
+  test('pages beneath a package root', () => {
+    expect(isPackageRoot('/modules/entity/deprecations')).toBe(false)
+    expect(isPackageRoot('/api/packages/entity/CHANGELOG')).toBe(false)
+    expect(isPackageRoot('/api/packages/entity/components/DruxtEntity')).toBe(false)
+  })
+
+  test('section indexes and unknown packages', () => {
+    expect(isPackageRoot('/modules')).toBe(false)
+    expect(isPackageRoot('/api')).toBe(false)
+    expect(isPackageRoot('/api/packages')).toBe(false)
+    // Private packages have no module header, so their pages need their own.
+    expect(isPackageRoot('/modules/docgen')).toBe(false)
+    expect(isPackageRoot('/api/packages/docgen')).toBe(false)
+    expect(isPackageRoot('/how-to/proxy')).toBe(false)
+  })
+})
+
+describe('moduleName', () => {
+  test('the core package keeps its bare name', () => {
+    expect(moduleName('druxt')).toBe('druxt')
+    expect(moduleName('entity')).toBe('druxt-entity')
+  })
+})

--- a/docs/nuxt/test/unit/module-package-root.test.js
+++ b/docs/nuxt/test/unit/module-package-root.test.js
@@ -15,6 +15,25 @@ describe('isPackageRoot', () => {
     }
   })
 
+  // The same page, reached by the URL its source filename spells out. The
+  // sitemap lists the collapsed path, but both resolve, and both used to
+  // print the module identity twice. Found by drx://docs.
+  test('index routes for a package root', () => {
+    expect(isPackageRoot('/modules/entity/README')).toBe(true)
+    expect(isPackageRoot('/modules/entity/README/')).toBe(true)
+    expect(isPackageRoot('/api/packages/entity/index')).toBe(true)
+    expect(isPackageRoot('/api/packages/entity/index/')).toBe(true)
+  })
+
+  // '' is falsy, so an empty segment slips past a truthiness guard on the
+  // segment after the package name.
+  test('doubled slashes do not read as a package root', () => {
+    expect(isPackageRoot('/api/packages/entity//CHANGELOG')).toBe(false)
+    expect(isPackageRoot('/modules/entity//deprecations')).toBe(false)
+    // Pinning that normalising the separators does not break the ordinary case.
+    expect(isPackageRoot('//modules//entity')).toBe(true)
+  })
+
   // These are the pages that keep their own header: the module header above
   // them names the module, not the page.
   test('pages beneath a package root', () => {
@@ -31,6 +50,11 @@ describe('isPackageRoot', () => {
     expect(isPackageRoot('/modules/docgen')).toBe(false)
     expect(isPackageRoot('/api/packages/docgen')).toBe(false)
     expect(isPackageRoot('/how-to/proxy')).toBe(false)
+    // An index segment collapses to the section, not to a package.
+    expect(isPackageRoot('/modules/README')).toBe(false)
+    expect(isPackageRoot('/api/packages/index')).toBe(false)
+    // A private package keeps its own header at either URL.
+    expect(isPackageRoot('/api/packages/docgen/index')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## The bug

`/modules/druxt/deprecations` renders the module identity twice and the page
title three times: the layout's module header ("Druxt / druxt / description"),
then a page header repeating the icon and package name, then the markdown's
own `# Deprecations`.

Two defects with different histories, corrected from my first account, which
said #810 added the page header. It did not; it only passed `:icon` and
`:mono` to a call that was already there.

**The body h1 is a regression.** `3c2b62f1` (2026-08-29 07:16Z) established
"the frontmatter title is the h1, the body must not repeat it" and demoted
`# Deprecations` to `## Deprecations` in `content/guide/deprecations.md`,
for exactly this symptom. `67ebe0ed` (2026-08-28 09:37Z) had already created
`content/modules/<pkg>/deprecations.md` with `# Deprecations`, on the
Diataxis branch. `git merge-base --is-ancestor 3c2b62f1 67ebe0ed` is false:
the fix landed 22 hours after those files were written, on a branch that
never contained them. The guide tree was then retired and the Diataxis tree
carried the pre-fix shape forward. Neither branch's CI could have caught it,
because neither held both halves.

**The duplicated identity block is new.** #793 (`31da9c26`) put the module
identity in the layout for every `/modules/<pkg>` and `/api/packages/<pkg>`
route. `b8f7de69` (2026-09-03, in the #808 stack) then added `AppPageHeader`
to `pages/modules/_.vue` to answer a review finding that module pages had no
h1, with #793 already an ancestor. That one was catchable on its own branch:
the finding was real, but the fix did not check what the layout already
rendered. #810 then made the second block a visual clone by passing the icon
and package name.

| Route | Before | After |
| --- | --- | --- |
| `/modules/druxt` | identity block twice, verbatim | once, h1 `Druxt` |
| `/modules/druxt/deprecations` | identity + page header + body h1 | identity, then h1 `Druxt core deprecations` |
| `/api/packages/entity` | identity block, then h1 `Entity` and a duplicate source link | once, h1 `Entity` |

## The fix

- `isPackageRoot(path)` in `components/app/icon/module/index.js` is the single
  test for "the module header is this page's header": `/modules/<pkg>` and
  `/api/packages/<pkg>`, gated to the packages the header covers.
- `ModuleHeader` renders its title as `h1` there and `span` elsewhere, so the
  page keeps exactly one h1 either way.
- `pages/modules/_.vue` and `pages/api/_.vue` skip their own header on those
  routes. The dropped "View source on GitHub" link resolves to the same URL as
  the header's Source button, verified on the deployed page.
- `PageHeader`'s `icon` and `mono` props go with it; nothing passes them now.
- The four `content/modules/*/deprecations.md` files lose their body
  `# Deprecations`. They were the only content pages carrying one; every other
  page in `content/` puts its title in frontmatter.

## Verification

`nuxt generate` on this branch, h1 count per page:

```
/modules                       h1x1  ['Druxt modules']
/modules/druxt                 h1x1  ['Druxt']
/modules/druxt/deprecations    h1x1  ['Druxt core deprecations']
/modules/entity/deprecations   h1x1  ['DruxtEntity deprecations']
/api/packages/entity/CHANGELOG h1x1  ['Release notes']
/how-to/proxy                  h1x1  ['Proxy the Drupal backend through Nuxt']
```

The suite that existed asserted the chrome was **present** on a module page,
never how much of it: `cy.contains('a', 'Source')` passes with two Source
links exactly as with one. The only h1 assertion was on `/modules`, which is
served by `pages/modules/index.vue` and was never duplicated.

- New unit test `test/unit/module-package-root.test.js` covers `isPackageRoot`
  across every module package, the pages beneath them, the section indexes and
  the private packages that have no module header.
- `test/cypress/e2e/modules.cy.js` asserts a single h1 on `/modules/entity`,
  `/api/packages/entity` and `/modules/entity/deprecations`.
- eslint, cspell and markdownlint clean; 142 docs unit tests pass.


## Review round (second commit, `d86c4752`)

Three findings from CodeRabbit on the GitHub PR, plus a fourth from
a second reviewer that the automated review missed. All four verified against the code
before acting, and each fix proven in both directions.

| # | Defect | Proof |
| --- | --- | --- |
| 1 | `/api/packages/entity//CHANGELOG` read as a package root: `''` is falsy, so a positional `if (fourth)` guard saw no fourth segment | new test, red on `4c260a4a` |
| 2 | The `h1` shipped **inside** `AppDropdown`'s `<button>`, which takes phrasing content only | present in the built artifact, not just dev |
| 3 | If the module README failed to load, the page suppressed its own header while the layout rendered none | see table below |
| 4 | `/modules/<pkg>/README` and `/api/packages/<pkg>/index` still printed the identity twice | new test, red on `4c260a4a` |

`isPackageRoot` now normalises the path (`split('/').filter(Boolean)`,
then pop a trailing `index`/`README`) and counts segments rather than
probing them positionally. The positional form is what produced defect 1:
it asked whether a later segment was truthy instead of how many there
were. Unit tests go `2 failed, 5 passed` on `4c260a4a` and `7 passed`
here; the full docs suite is 144 passed across 9 suites.

### Why the h1 is `sr-only`, and please leave it that way

The visible module title is the switcher's trigger, and a trigger is a
`<button>`, whose content model is phrasing content only. An `h1` there is
invalid and its heading semantics are not reliably exposed. Wrapping the
other way round does not work either: `AppDropdown`'s root is a `<div>`,
and a div inside an `h1` is invalid in the opposite direction. Restructuring
`AppDropdown` would touch three other call sites for a cosmetic gain.

So the heading sits beside the visible title as an `sr-only` element, which
is already the house pattern here (`BreadcrumbBar`, `Search`, the layout's
skip link). The known cost: a screen reader hears "Entity" as a heading and
then the switcher button labelled "Entity druxt-entity", so the name lands
twice in a row. That is a mild redundancy traded against invalid markup and
unreliable heading exposure. It is deliberate, not an oversight.

Counting `h1`s cannot see a heading nested somewhere it may not be, so the
e2e spec also asserts `cy.get('button h1').should('not.exist')`. That
detector was checked against the old markup (true), the new markup (false)
and an `h1` following a closed button (false), rather than assumed to
discriminate.

### Defect 3, measured

`content/modules/entity/README.md` removed, then generated, on each side:

| `/api/packages/entity` | h1 | Source link | module header |
| --- | --- | --- | --- |
| before | none | absent | absent |
| after | `druxt-entity` | present | present |

`ModuleHeader` now renders on `pkg` alone and falls back to the npm package
name for its title. The point is not the fallback text: `inModuleHeader` and
`ModuleHeader`'s render condition are two predicates that must agree, held
together by nothing, and any future edit to either could separate them
silently. Rendering on `pkg` makes the invariant true instead of assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module headers now remain visible when README content cannot be loaded.
  * Package-root pages display consistent titles, descriptions, metadata, and a single accessible page heading.
  * Duplicate headers and redundant identity details are no longer shown on package-root pages.

* **Documentation**
  * Improved deprecations page heading structure across module documentation.

* **Tests**
  * Added coverage for package-root URL detection and single-heading rendering across module and API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->