### PR TITLE
fix(docs): correct two redirect targets and verify the map in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,11 @@ jobs:
           yarn install --immutable
           yarn generate
 
+      # The map is keyed on $host$request_uri and its targets are pages, so
+      # a typo only shows as a 404 in production. dist exists at this point.
+      - name: Verify the redirects map
+        run: .lagoon/verify-redirects.sh
+
       # Node 22 from here, matching the node:22 image the GitLab job uses.
       # unlighthouse-ci@0.18.0 declares node >=22.18.0 and means it: on 20 it
       # dies importing `glob` from node:fs/promises, which does not exist before

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             if files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename'); then
               deps=false; site=false; packages=false
               echo "$files" | grep -qE '(^|/)(yarn\.lock|package\.json|\.yarnrc\.yml)$' && deps=true
-              echo "$files" | grep -qE '^(docs/nuxt/|packages/docgen/|packages/[^/]+/README\.md)' && site=true
+              echo "$files" | grep -qE '^(docs/nuxt/|packages/docgen/|packages/[^/]+/README\.md|\.lagoon/)' && site=true
               echo "$files" | grep -qE '^packages/' && packages=true
             else
               echo "file listing failed; running everything" >&2

--- a/.lagoon/redirects-map.conf
+++ b/.lagoon/redirects-map.conf
@@ -52,7 +52,7 @@
 
 ~^schema.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/schema/nuxtModule;
 ~^(www\.)?druxtjs\.org/api/mixins/schema\.html/?$ https://druxtjs.org/api/packages/schema/mixins/schema;
-~^(www\.)?druxtjs\.org/api/stores/schema\.html/?$ https://druxtjs.org/api/packages/schema/store/schema;
+~^(www\.)?druxtjs\.org/api/stores/schema\.html/?$ https://druxtjs.org/api/packages/schema/stores/schema;
 
 ~^site.druxtjs.org/api/nuxtModule.html https://druxtjs.org/api/packages/site/nuxtModule;
 ~^(www\.)?druxtjs\.org/api/components/DruxtSite\.html/?$ https://druxtjs.org/api/packages/site/components/DruxtSite;
@@ -94,6 +94,6 @@
 ~^(www\.)?druxtjs\.org/guide/deprecations\.html/?$ https://druxtjs.org/modules/druxt/deprecations;
 ~^(www\.)?druxtjs\.org/guide/CONTRIBUTING/?$ https://druxtjs.org/how-to/contributing;
 ~^(www\.)?druxtjs\.org/guides/custom-module/?$ https://druxtjs.org/tutorials/first-custom-module;
-~^(www\.)?druxtjs\.org/guides/node-client/?$ https://druxtjs.org/how-to/use-the-node-client;
+~^(www\.)?druxtjs\.org/guides/node-client/?$ https://druxtjs.org/how-to/use-the-druxt-client;
 ~^(www\.)?druxtjs\.org/api/components/?$ https://druxtjs.org/components;
 ~^(www\.)?druxtjs\.org/modules/site/getting-started/?$ https://druxtjs.org/tutorials/getting-started;


### PR DESCRIPTION
Two redirect entries pointed at pages that do not exist, so both sent visitors to a dead URL.

| Redirect | Was | Now |
| --- | --- | --- |
| `/api/stores/schema.html` | `/api/packages/schema/store/schema` | `/api/packages/schema/stores/schema` |
| `/guides/node-client` | `/how-to/use-the-node-client` | `/how-to/use-the-druxt-client` |

The first is a `store` / `stores` typo. The second names a page that has never existed under that name; `use-the-druxt-client` is the only node-client content in the docs.

Neither surfaced as a 404. Unknown URLs return 200 with the SPA shell, so a wrong target renders as a working page and no log or uptime check reports it.

`.lagoon/verify-redirects.sh` already caught both, but nothing ran it. It now runs in `audit-seo`, straight after the site is generated, where `dist` is available.

Verified in both directions rather than trusting a green run: against the unfixed map it exits 1 and names exactly these two entries, and against the fixed map it exits 0 with all 63 entries verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the schema store redirect to point to the correct API endpoint.
  - Corrected the guides redirect for the Node client to use the current “How to use the Druxt client” page.
  - Improved redirect validation during site checks to help ensure configured redirects resolve correctly after site generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->