### PR TITLE
fix(site): serve the legacy druxtjs.org redirects from the app, not nginx

### DIFF
--- a/docs/nuxt/Dockerfile
+++ b/docs/nuxt/Dockerfile
@@ -10,6 +10,8 @@ RUN yarn build:docs
 # Build static files.
 FROM amazeeio/node:16@sha256:11f2d4ce2e741dbdc87cf4929e3a30f0d06ece1e137b33073aa291154d067316
 COPY --from=builder /app/docs/nuxt /app
+# scripts/serve.js answers the map's druxtjs.org rules; nginx never sees that host.
+COPY --from=builder /app/.lagoon/redirects-map.conf /app/redirects-map.conf
 
 # corepack reads docs/nuxt/package.json's own packageManager field (this
 # stage only has docs/nuxt, not the monorepo root, so it can't fall back to

--- a/docs/nuxt/scripts/serve.js
+++ b/docs/nuxt/scripts/serve.js
@@ -7,12 +7,44 @@
  * entry advertises - and answers unknown paths with the SPA shell as a 200.
  * This serves the same dist with the redirect reversed and a real 404
  * status, using node core only so the runtime image needs no dependencies.
+ *
+ * Legacy URLs are redirected from the same map nginx uses for the package
+ * subdomains. druxtjs.org itself is routed to this server, not nginx, so
+ * the map's druxtjs.org rules only take effect when answered here.
  */
 const http = require('http')
 const fs = require('fs')
 const path = require('path')
 
 const DIST = path.join(__dirname, '..', 'dist')
+
+// The image copies the map beside the site; a repo checkout has it in .lagoon.
+const REDIRECTS_MAPS = [
+  process.env.REDIRECTS_MAP,
+  path.join(__dirname, '..', 'redirects-map.conf'),
+  path.join(__dirname, '..', '..', '..', '.lagoon', 'redirects-map.conf'),
+].filter(Boolean)
+
+// A druxtjs.org rule: `~^(www\.)?druxtjs\.org<path regex>/?$ <target>;`
+const RULE = /^~\^\(www\\\.\)\?druxtjs\\\.org(\S+)\/\?\$\s+(\S+);$/
+
+/**
+ * Parse the druxtjs.org rules out of an nginx redirects map.
+ *
+ * Targets are made relative so a preview environment redirects within its
+ * own host, and slashless so the redirect lands in one hop.
+ *
+ * @param {string} conf - The map file contents.
+ * @returns {{ pattern: RegExp, target: string }[]} Rules in file order.
+ */
+const parseRedirects = (conf) => String(conf).split('\n').reduce((rules, line) => {
+  const match = line.trim().match(RULE)
+  if (!match || match[2].includes('$')) return rules
+  const target = match[2].replace(/^https:\/\/druxtjs\.org/, '').replace(/\/+$/, '')
+  return rules.concat({ pattern: new RegExp(`^${match[1]}/?$`), target: target || '/' })
+}, [])
+
+const loadRedirects = (file) => (file ? parseRedirects(fs.readFileSync(file, 'utf8')) : [])
 
 const TYPES = {
   '.html': 'text/html; charset=utf-8',
@@ -79,7 +111,7 @@ const notModified = (req, stats) => {
   return Boolean(ims) && new Date(ims) >= new Date(stats.mtime.toUTCString())
 }
 
-const createHandler = (dist) => (req, res) => {
+const createHandler = (dist, redirects = []) => (req, res) => {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
     return send(res, 405, { Allow: 'GET, HEAD' }, 'Method Not Allowed')
   }
@@ -93,6 +125,12 @@ const createHandler = (dist) => (req, res) => {
     search = url.search
   } catch (e) {
     return send(res, 400, {}, 'Bad Request')
+  }
+
+  // Legacy URLs go first so their slashed form also lands in one hop.
+  const legacy = redirects.find(({ pattern }) => pattern.test(pathname))
+  if (legacy) {
+    return send(res, 301, { Location: legacy.target + search })
   }
 
   // Canonical URLs carry no trailing slash: strip it with one permanent
@@ -118,12 +156,18 @@ const createHandler = (dist) => (req, res) => {
   return send(res, 404, { 'Content-Type': 'text/plain; charset=utf-8' }, 'Not Found', headOnly)
 }
 
-module.exports = { createHandler, DIST }
+module.exports = { createHandler, parseRedirects, loadRedirects, DIST, REDIRECTS_MAPS }
 
 if (require.main === module) {
   const host = process.env.HOST || '0.0.0.0'
   const port = Number(process.env.PORT) || 3000
-  http.createServer(createHandler(DIST)).listen(port, host, () => {
+  const map = REDIRECTS_MAPS.find((file) => statFile(file))
+  const redirects = loadRedirects(map)
+  http.createServer(createHandler(DIST, redirects)).listen(port, host, () => {
     process.stdout.write(`serve: ${DIST} on http://${host}:${port}\n`)
+    // Logged so a deploy shows whether the map made it into the image.
+    process.stdout.write(map
+      ? `serve: ${redirects.length} legacy redirects from ${map}\n`
+      : 'serve: no redirects map found, legacy URLs will 404\n')
   })
 }

--- a/docs/nuxt/test/unit/serve.test.js
+++ b/docs/nuxt/test/unit/serve.test.js
@@ -3,7 +3,7 @@ import http from 'http'
 import os from 'os'
 import path from 'path'
 
-const { createHandler } = require('~/scripts/serve')
+const { createHandler, parseRedirects, loadRedirects, REDIRECTS_MAPS } = require('~/scripts/serve')
 
 const request = (server, urlPath, options = {}) => new Promise((resolve, reject) => {
   const { port } = server.address()
@@ -109,5 +109,78 @@ describe('scripts/serve', () => {
     expect(res.status).toBe(500)
     const after = await request(server, '/guide')
     expect(after.status).toBe(200)
+  })
+})
+
+describe('scripts/serve legacy redirects', () => {
+  const conf = [
+    '# comment',
+    '',
+    '~^(www\\.)?druxtjs\\.org/guide/theming/?$ https://druxtjs.org/how-to/theming;',
+    '~^(www\\.)?druxtjs\\.org/guide/deprecations\\.html/?$ https://druxtjs.org/modules/druxt/deprecations;',
+    '~^(www\\.)?druxtjs\\.org/api/menu\\.html/?$ https://druxtjs.org/api/packages/menu/;',
+    '~^blocks.druxtjs.org/api/mixins/block.html https://druxtjs.org/api/packages/blocks/mixins/block;',
+    '~^blocks.druxtjs.org https://druxtjs.org$request_uri;',
+  ].join('\n')
+
+  let dist
+  let server
+
+  beforeAll(async () => {
+    dist = fs.mkdtempSync(path.join(os.tmpdir(), 'serve-legacy-test-'))
+    fs.writeFileSync(path.join(dist, '404.html'), '<h1>not found</h1>')
+    server = http.createServer(createHandler(dist, parseRedirects(conf)))
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  })
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve))
+    fs.rmSync(dist, { recursive: true, force: true })
+  })
+
+  test('parses only the druxtjs.org rules, with relative slashless targets', () => {
+    expect(parseRedirects(conf)).toEqual([
+      { pattern: /^\/guide\/theming\/?$/, target: '/how-to/theming' },
+      { pattern: /^\/guide\/deprecations\.html\/?$/, target: '/modules/druxt/deprecations' },
+      { pattern: /^\/api\/menu\.html\/?$/, target: '/api/packages/menu' },
+    ])
+  })
+
+  test('redirects a legacy URL permanently, query preserved', async () => {
+    const res = await request(server, '/guide/theming?ref=1')
+    expect(res.status).toBe(301)
+    expect(res.headers.location).toBe('/how-to/theming?ref=1')
+  })
+
+  test('the slashed and .html forms land in one hop', async () => {
+    const slashed = await request(server, '/guide/theming/')
+    expect(slashed.headers.location).toBe('/how-to/theming')
+    const html = await request(server, '/guide/deprecations.html')
+    expect(html.headers.location).toBe('/modules/druxt/deprecations')
+  })
+
+  test('a rule is anchored, not a prefix', async () => {
+    const res = await request(server, '/guide/theming-extra')
+    expect(res.status).toBe(404)
+  })
+
+  test('the repo map loads every druxtjs.org rule', () => {
+    const map = REDIRECTS_MAPS.find((file) => file.endsWith(path.join('.lagoon', 'redirects-map.conf')))
+    const rules = fs.readFileSync(map, 'utf8').split('\n')
+      .filter((line) => line.startsWith('~^(www\\.)?druxtjs\\.org'))
+    expect(rules.length).toBeGreaterThan(0)
+    const redirects = loadRedirects(map)
+    expect(redirects).toHaveLength(rules.length)
+    const legacy = (pathname) => (redirects.find(({ pattern }) => pattern.test(pathname)) || {}).target
+    expect(legacy('/guide')).toBe('/tutorials')
+    expect(legacy('/guide/getting-started')).toBe('/tutorials/getting-started')
+    expect(legacy('/guide/theming')).toBe('/how-to/theming')
+    expect(legacy('/guide/deprecations')).toBe('/modules/druxt/deprecations')
+    expect(legacy('/guides/node-client')).toBe('/how-to/use-the-druxt-client')
+    expect(legacy('/api/stores/schema.html')).toBe('/api/packages/schema/stores/schema')
+  })
+
+  test('no map means no redirects, not a crash', () => {
+    expect(loadRedirects(undefined)).toEqual([])
   })
 })


### PR DESCRIPTION
## Problem

`.lagoon.yml` routes `druxtjs.org` and `www.druxtjs.org` to the `app` service. The `nginx` service, which is the only thing that loads `.lagoon/redirects-map.conf`, serves the package subdomains alone. So the 49 `druxtjs.org` rules in the map, the `/guide/*` and `/guides/*` Diataxis moves among them, can never fire. `verify-redirects.sh` checks the map's syntax and targets, not which service receives the host, so it stayed green.

Today the legacy `/guide/*` pages are still served by the old site. After the docs restructure ships, `scripts/serve.js` answers them with a real 404.

## Fix

`scripts/serve.js` loads the same map file and answers its `druxtjs.org` rules itself, before the trailing-slash redirect so a slashed legacy URL lands in one hop. Targets are made relative so a preview environment stays on its own host, and slashless so the canonical redirect does not add a second hop.

The runtime image copies `.lagoon/redirects-map.conf` beside the site; a repo checkout finds it in `.lagoon/`. `REDIRECTS_MAP` overrides both. The server logs how many rules it loaded and from where, or that it found no map, so the deploy log shows whether the file made it into the image.

The map stays the single source of truth for both services.

## Verification

- `docs/nuxt/test/unit/serve.test.js`: six new cases. Parsing (druxtjs.org rules only, subdomain and `$request_uri` rules skipped, targets relative and slashless), a 301 with the query preserved, slashed and `.html` forms in one hop, anchoring, the real map loading every `druxtjs.org` rule and resolving `/guide`, `/guide/getting-started`, `/guide/theming`, `/guide/deprecations`, `/guides/node-client` and `/api/stores/schema.html` to the targets corrected in #819, and no map meaning no redirects. With the lookup disabled, two of them fail; with it, 17 of 17 pass.
- `node scripts/serve.js` from the checkout logs `49 legacy redirects` and answers `/guide/theming/` with `301 /how-to/theming`, `/guide/deprecations.html` with `301 /modules/druxt/deprecations`, and `/guide/nope` with `404`.
- The Lagoon preview for this branch, built from the runtime image: all 49 `druxtjs.org` rules in the map answer with a 301 to the expected relative target in one hop, and every target returns 200. `/guide/theming/` and `/guide/theming?ref=1` land on `/how-to/theming` and `/how-to/theming?ref=1`; `/guide/nope` is a 404; the trailing-slash canonical redirect is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added automatic permanent redirects for legacy URLs to their current destinations.
  - Redirects now support trailing-slash and `.html` URL variants while preserving query parameters.
  - Improved handling of legacy redirect rules, including accurate path matching and graceful behavior when redirect configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->